### PR TITLE
Add /begin skill and server-backed lessons (post-onboarding handoff)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "altitude",
       "source": "./",
-      "description": "Learn to code by building a real project with an AI coding agent — four skills that enforce small steps, predict-before-run, and knowledge-graph quizzes. Never ship a line you can't explain."
+      "description": "Learn to code by building a real project with an AI coding agent — five skills that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "altitude",
-  "description": "Learn to code by building a real project with an AI coding agent \u2014 four skills (start-project, plan-journey, next-lesson, adopt-project) that enforce small steps, predict-before-run, and knowledge-graph quizzes. Never ship a line you can't explain.",
-  "version": "0.2.2",
+  "description": "Learn to code by building a real project with an AI coding agent \u2014 five skills (begin, start-project, plan-journey, next-lesson, adopt-project) that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
+  "version": "0.3.0",
   "author": {
     "name": "Jason Ku"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "altitude",
-  "description": "Learn to code by building a real project with an AI coding agent \u2014 five skills (begin, start-project, plan-journey, next-lesson, adopt-project) that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
+  "description": "Learn to code by building a real project with an AI coding agent \u2014 seven skills (begin, start-project, plan-journey, next-lesson, adopt-project, connect, status) plus dormant-by-default session hooks that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
   "version": "0.3.0",
   "author": {
     "name": "Jason Ku"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cp -r altitude-skills/skills/* ~/.claude/skills/
 
 For the standalone method, open a new Claude Code session in an empty folder and run `/start-project`. If you planned a subscribed journey on Altitude, install its CLI, connect with `/altitude:connect`, and run `/altitude:begin` instead.
 
-Session-capture hooks will land in the plugin in a follow-up commit.
+The plugin also bundles Altitude's session hooks (`hooks/`). They stay fully dormant unless you're working inside a project bound to a subscribed journey (`altitude bind` / `/altitude:begin`) — no events, gates, or context injection anywhere else. With a bound project, they capture session evidence for your journey and run the plan/diff/retro gates. Gates fail open: a crashed hook never blocks your work. The `/altitude:connect` and `/altitude:status` skills manage the link.
 
 **Using Codex or Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which both support — only the target folder changes:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Altitude — learn to code by building
 
-Four Agent skills that turn an AI coding agent into a tutor instead of a ghostwriter: pick a real project (or adopt one you've already built), plan it with learning as the primary objective, then build it one small, fully-understood step at a time.
+Five Agent skills that turn an AI coding agent into a tutor instead of a ghostwriter: begin a journey planned with Altitude, or use the standalone free method to pick (or adopt) a real project and plan it locally — then build it one small, fully-understood step at a time.
 
 ## Where it takes you
 
@@ -12,27 +12,30 @@ Wherever you're starting from, the destination is the same — a real product yo
 
 The metaphor: concepts learned in isolation are loose leaves — hard to sort, easy to lose. A real project is a tree. The **trunk** is the project's core components, the **branches** are the build plan, and the **leaves** are every concept you learn along the way, attached where they belong.
 
-## The four skills
+## The five skills
 
 | Skill | What it does |
 |---|---|
+| `/begin` | Starts a journey planned on the Altitude web app, binds it to a local workshop, writes its plan locally, and rolls into the first task |
 | `/start-project` | Interviews you for a project idea sized to your experience, defines the MVP, maps the trunk |
 | `/plan-journey` | Walks every design decision with you (and checks you understand it), builds the sectioned learning plan, seeds your knowledge graph |
-| `/next-lesson` | Executes one task: small code steps, fill-in-the-blank placeholders, predict-before-run, quizzes driven by your knowledge graph, graph update at the end |
+| `/next-lesson` | Executes one task in either mode: local plans keep evidence in your knowledge graph; bound subscriber journeys sync progress and mastery with Altitude |
 | `/adopt-project` | Already have a project? Honest triage, an understanding inventory, a file map with no mystery boxes, and a forward plan with reclaim tasks — replaces the first two skills, feeds the same `/next-lesson` loop |
 
-Rather not install anything? [PROMPTS.md](PROMPTS.md) has the copy/paste version of every step.
+Rather not install anything? [PROMPTS.md](PROMPTS.md) has the copy/paste version of the standalone free method.
 
 ## Already started a project?
 
 If you've got an existing codebase — especially one an AI wrote for you that you can't fully explain — don't start over. Run `/adopt-project` in that folder. It triages the project honestly (adopt it, trim it first, or — rarely — rebuild with your old repo as the spec), inventories what you actually understand (an inventory, not an exam), maps every file so nothing on disk is a mystery box, and writes a plan that keeps building your app forward while you reclaim the code you already have, piece by piece. From there, `/next-lesson` works exactly the same.
 
-All state lives in a `learning/` folder in your project — plain markdown you own:
+In the standalone free method, all state lives in a `learning/` folder in your project — plain markdown you own:
 
 - `learning/project.md` — your project, MVP, and trunk
 - `learning/plan.md` — the sectioned plan with locked decisions
 - `learning/knowledge-graph.md` — the living map of what you actually know
 - `learning/file-map.md` — why every file and folder in your repo exists
+
+The free method is complete and works standalone: `/start-project` + `/plan-journey` (or `/adopt-project`), then `/next-lesson`. An Altitude subscription adds a journey planned on the web, the server-side learning map, scheduled reviews, and progression gates. `/begin` materializes that journey as a readable local `learning/plan.md`; `/next-lesson` refreshes it and syncs completed tasks while you remain entitled. If a subscription pauses, the local plan remains yours and lessons continue in free mode with local knowledge-graph evidence.
 
 ## Install
 
@@ -50,7 +53,9 @@ git clone https://github.com/jasonku09/altitude-skills.git
 cp -r altitude-skills/skills/* ~/.claude/skills/
 ```
 
-Either way: open a new Claude Code session in an empty folder and run `/start-project`. That's it — no hooks, no config, no setup.
+For the standalone method, open a new Claude Code session in an empty folder and run `/start-project`. If you planned a subscribed journey on Altitude, install its CLI, connect with `/altitude:connect`, and run `/altitude:begin` instead.
+
+Session-capture hooks will land in the plugin in a follow-up commit.
 
 **Using Codex or Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which both support — only the target folder changes:
 
@@ -65,28 +70,29 @@ Copied skills don't auto-update — re-run the clone + copy to pick up new versi
 ## How to use it
 
 - **Starting from zero?** Make an empty folder, open Claude Code in it, run `/start-project`. When it's done, run `/plan-journey`. One sitting each.
+- **Starting a journey planned on Altitude?** Connect your account, run `/begin`, and follow the folder and binding steps. It takes you straight into the first server-planned task.
 - **Already have a codebase?** Open Claude Code in that folder and run `/adopt-project` instead — it replaces both of the above.
-- **From then on, it's `/next-lesson`, over and over.** That's the whole loop, for months. One lesson is one small task — expect 30–60 minutes, 3–5 sittings a week.
+- **From then on, it's `/next-lesson`, over and over.** That's the whole loop in both free and paid modes, for months. One lesson is one small task — expect 30–60 minutes, 3–5 sittings a week.
 - **One lesson per sitting — really.** Don't binge five in a night. The gap between sessions is where memory consolidates, and it's exactly what the next lesson's review quiz tests. Hungry for more is the perfect place to stop.
-- **Start each sitting in a fresh session.** Everything the tutor needs to remember lives in `learning/` — a brand-new session picks up exactly where the last one left off.
+- **Start each sitting in a fresh session.** In free mode, the tutor picks up from `learning/`; in paid mode, it refreshes the bound journey first. Either route restores exactly where you left off.
 - **Do the typing yourself.** When the tutor dictates a command, you run it in your terminal. When it leaves `TODO(you)` blanks, fill them in your editor and hit save — it's watching the file, not the chat.
 - **Answer quizzes from your head, in your own words.** Don't look it up first. A wrong answer isn't a failure — it's the data that decides what gets taught next.
 - **Life happens — bring it to the lesson.** Broke something on your own? Say so; that's a lesson, and a good one. Want a feature that isn't in the plan? Ask; the plan is a living backlog, not a contract.
-- **Read your `learning/` files anytime; let the lessons write them.** Graph statuses only move on demonstrated evidence — promoting yourself to `understood` by hand just cheats the quizzes that keep you honest.
+- **Read your `learning/` files anytime; let the lessons write them.** In free mode, graph statuses move only on demonstrated evidence. In paid mode, `plan.md` is a readable projection of the server journey, so park ideas in a lesson or edit the journey on the web.
 
 ## Ground rules baked into the skills
 
 - One small step at a time. The pause between lessons is the pedagogy.
 - Predict before you run. A wrong prediction is the best teacher you'll meet.
-- Quizzes come from *your* graph — you're never re-quizzed on what you've already demonstrated (and still remember).
+- Quizzes come from your evidence — the local graph in free mode or your server-side learning map in paid mode — so demonstrated, still-fresh concepts do not become busywork.
 - No mystery boxes: every file in your repo is either explained or explicitly parked. When a scaffold dumps fifteen files into your folder, you get the tour before you build on them.
 - **Never ship a single line of code you cannot explain.**
 
-## The one thing these skills can't do
+## The free method's one limitation
 
-The `learning/` folder is the agent's memory of what you know: every session reads it, quizzes come from it, and nothing in it changes without evidence. What no skill can do is **start a session on its own**. Spaced repetition works because reviews arrive on the forgetting curve's schedule — right when a concept is about to fade — and these skills can only review you when you show up. The scheduling loop is you.
+In the standalone method, the `learning/` folder is the agent's memory of what you know: every session reads it, quizzes come from it, and nothing changes without evidence. A local skill cannot **start a session on its own**, so the scheduling loop is you.
 
-I'm building an app that closes that loop: same method, but the review schedule runs for you — it notices what's about to fade and comes to you. If you'd rather not be your own scheduler, watch this repo — the waitlist link lands here soon.
+An Altitude subscription adds that server loop: the journey, learning map, scheduled reviews, and progression gates live with your account while the readable plan stays in your project. The teaching method itself remains available here for free.
 
 ## License
 

--- a/hooks/field-mapping.json
+++ b/hooks/field-mapping.json
@@ -1,0 +1,8 @@
+{
+  "fields": {
+    "session_id": "session_id",
+    "cwd": "cwd",
+    "tool_name": "tool_name",
+    "last_assistant_message": "last_assistant_message"
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,89 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "altitude",
+            "args": [
+              "hook",
+              "session-start",
+              "--agent",
+              "claude-code",
+              "--mapping",
+              "${CLAUDE_PLUGIN_ROOT}/hooks/field-mapping.json",
+              "--print-context",
+              "--nudge",
+              "Run /altitude:next-lesson to continue (or /altitude:begin if this is your first session)."
+            ],
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "altitude",
+            "args": [
+              "hook",
+              "pre-tool-use",
+              "--agent",
+              "claude-code",
+              "--mapping",
+              "${CLAUDE_PLUGIN_ROOT}/hooks/field-mapping.json",
+              "--gate",
+              "plan"
+            ],
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "altitude",
+            "args": [
+              "hook",
+              "pre-tool-use",
+              "--agent",
+              "claude-code",
+              "--mapping",
+              "${CLAUDE_PLUGIN_ROOT}/hooks/field-mapping.json",
+              "--gate",
+              "diff"
+            ],
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "altitude",
+            "args": [
+              "hook",
+              "stop",
+              "--agent",
+              "claude-code",
+              "--mapping",
+              "${CLAUDE_PLUGIN_ROOT}/hooks/field-mapping.json",
+              "--gate",
+              "retro"
+            ],
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/begin/SKILL.md
+++ b/skills/begin/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: begin
+description: Begin a server-planned Altitude journey and bind it to a local workshop. Use when the user says "begin my journey", "start my Altitude journey", "I just connected my workshop", invokes /begin, or is starting their first session after pairing or connecting Altitude.
+---
+
+# Begin
+
+You are a patient senior engineer welcoming a beginner into their Altitude journey. Move one step at a time, keep the learner's hands on the keyboard, and leave no dead ends: this skill either starts the server-planned route, reconnects them to it, or points them clearly to the standalone free method.
+
+## Hard rules
+
+- Run `altitude task --json` first. Capture its output for your own routing; never print the raw JSON, stderr, or a stack trace to the learner.
+- Any missing command, nonzero exit, malformed response, or other CLI error means **free mode for this attempt**. Degrade warmly and keep going.
+- One command at a time. The learner types setup commands in their own terminal, tells you what happened, and gets an explanation before the next command.
+- Never overwrite a learner-authored `learning/plan.md`. Only a plan whose first line is the exact generated marker below may be refreshed from the server.
+- Never duplicate application setup that the journey already teaches. In particular, leave `git init`, scaffolding, and project tool installation to the journey's tasks when its first section covers them.
+
+## Step 1 — Find their route
+
+Run `altitude task --json` in the current working directory and parse the single JSON object privately.
+
+- If the command is unavailable or errors, explain in plain language that Altitude's standalone skills still work without an account: use `/start-project` for a new project or `/adopt-project` for an existing codebase. If they do have an Altitude account and want its planned journey, walk them through installing the CLI with `npm install -g @learnaltitude/cli`, then connecting with `/altitude:connect` (or `altitude connect` outside the installed plugin). Give and explain one command at a time; do not run these learner setup commands for them.
+- If `connected` is false, give the same two honest routes: continue free with `/start-project` or `/adopt-project`, or connect their account with `/altitude:connect`. Do not call the account path required for learning.
+- If connected but `journey` is null, say that this account does not have a journey ready yet. Ask them to plan or select one on the Altitude web app and run `/altitude:begin` again, or offer the standalone free route now.
+- If a journey is present but `entitled` is not true and this directory is not already bound, explain that binding a new workshop needs an active subscription. The journey remains on their account; offer the standalone free route now instead of attempting `altitude bind`.
+
+Treat this directory as bound only when `binding` is non-null and its `project_root` resolves to the current project root. A binding for a different folder does not bind this one.
+
+## Step 2 — Protect existing work
+
+When a journey is present but the current directory is not bound, inspect `learning/plan.md` before doing anything else.
+
+If it exists and its first line is not exactly:
+
+`<!-- altitude:generated from your journey — local edits don't sync; park ideas in a lesson or edit on the web -->`
+
+stop. Never overwrite or rename it. Explain the three options honestly:
+
+1. Keep this project in the free method. Its plan is theirs, and `/next-lesson` continues to work as it always has.
+2. Start the paid journey in a fresh folder. Offer to guide them through creating it now.
+3. Adopt this project into their Altitude account later. Account-side project adoption is coming, but is not available yet.
+
+Wait for their choice. These are genuine alternatives, so a choice panel is acceptable if the host supports one.
+
+## Step 3 — Make the journey's home
+
+For a fresh start, derive a conservative kebab-case folder name from the journey title: lowercase it, replace each run of non-alphanumeric characters with one hyphen, and trim leading or trailing hyphens. Show the proposed name and let the learner change it.
+
+Then guide them through these beats one at a time:
+
+1. Ask them to run `mkdir <journey-name>` themselves and report what happened.
+2. Ask them to run `cd <journey-name>` themselves. Make sure the agent's working directory is now that folder too; if their host requires reopening the agent there, explain that plainly and resume `/altitude:begin` after they do.
+3. Ask them to run `altitude bind`. If the CLI says this folder is bound to another journey, explain what `--force` would replace and get their explicit choice before asking them to run `altitude bind --force`.
+4. Re-run `altitude task --json` privately. Continue only after its `binding.project_root` resolves to this project and the journey is present. If binding fails, explain the friendly CLI message without exposing raw diagnostics; offer the free route rather than trapping them.
+
+Creating and entering the folder is the first lesson beat, not clerical work: explain that the folder is the project's home and let their hands establish it.
+
+## Step 4 — Materialize `learning/plan.md`
+
+Create `learning/` if needed and render the bound journey to `learning/plan.md`. The output is deterministic: for the same journey object, write the same UTF-8 bytes, use LF line endings, preserve the arrays' supplied order, and end with one newline.
+
+Render exactly this structure:
+
+1. The first line is this byte-exact generated marker:
+
+   `<!-- altitude:generated from your journey — local edits don't sync; park ideas in a lesson or edit on the web -->`
+2. Add a blank line, then `# <journey.title>`.
+3. If `summary` is non-null and non-empty, add a blank line and its text verbatim.
+4. If `build_brief` is non-null and non-empty, add `## Locked decisions` surrounded by blank lines, then append the markdown string verbatim. Do not summarize, reflow, reorder, or reinterpret it.
+5. For each section in the supplied order, add a blank line and `## NN · <section.title>`, where `NN` is the section's numeric `position` left-padded to two digits. On the next non-blank line write the section description verbatim when present.
+6. Under each section, render its tasks in supplied order. A task whose `status` is `completed` is `- [x] <task.title>`; every other status is `- [ ] <task.title>`. If its `id` equals `current_task.id`, append ` ← you are here`. When a task description is present, put it on the following line, prefixing every description line with two spaces.
+
+Use exactly one blank line between top-level blocks. Apart from the required two-space task-description prefix, preserve server text verbatim. Never put IDs, inferred tasks, timestamps, or other nondeterministic data in the file.
+
+## Step 5 — Point out the route, then begin
+
+Give a short orientation, not a second planning session: name the journey, list its sections at a glance, and point out the current section and task. If section 1 already covers git, scaffolding, or setup, explicitly leave those beats to it.
+
+Then continue directly with `/altitude:next-lesson` behavior for the current task. Do not make the learner invoke another skill just to get started; this is one skill family and the handoff should feel continuous.
+
+## Already bound
+
+If the first probe shows that this project is already bound and has a journey, say so warmly, then continue directly with `/altitude:next-lesson` behavior. This includes a paused subscription; `next-lesson` gives the one-time notice and continues from the surviving local plan. Do not re-bind, rebuild local learning state here, or leave them at a dead end; `next-lesson` owns the server refresh and lesson loop.

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -1,0 +1,15 @@
+---
+description: Connect this Claude Code installation to the user's Altitude account.
+disable-model-invocation: true
+allowed-tools: Bash(claude --version) Bash(altitude connect *) Bash(altitude status)
+---
+
+Connect the current Claude Code installation to Altitude:
+
+1. Run `claude --version` and take the leading semantic version number.
+2. Start `altitude connect --agent claude-code --agent-version <version> --next-hint "Open your coding agent in your project folder and run /altitude:begin to start your first lesson."` in the background.
+3. Relay the verification URL and one-time code from its output to the user immediately.
+4. Wait for the user to confirm in the browser, then report whether the command completed successfully.
+5. Run `altitude status` and summarize the connection, binding, and journey state.
+
+Do not alter the device flow or send credentials anywhere except through the `altitude` CLI.

--- a/skills/next-lesson/SKILL.md
+++ b/skills/next-lesson/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: next-lesson
-description: Execute the next task of a learning project — small code steps with fill-in placeholders, predict-before-run checks, quizzes driven by the knowledge graph, and a graph update at the end. Use when the user says "next lesson", "let's continue the project", "next task", or invokes /next-lesson.
+description: Execute the next task of a free local or server-planned Altitude learning project — small code steps with fill-in placeholders, predict-before-run checks, and evidence-based review. Use when the user says "next lesson", "let's continue the project", "next task", or invokes /next-lesson.
 ---
 
 # Next Lesson
 
 You are a patient senior engineer pair-building with a beginner whose goal is **understanding, not throughput**. This skill executes exactly **one task** of their plan, teaching as it goes. The learner should end every lesson able to explain everything that was built in it.
 
-Requires `learning/plan.md` and `learning/knowledge-graph.md`. If missing, point to `/start-project` and `/plan-journey` — or `/adopt-project` if they already have a codebase.
+Free mode requires `learning/plan.md` and `learning/knowledge-graph.md`. Paid mode materializes `learning/plan.md` from the bound server journey and keeps mastery server-side. If neither a local plan nor a server journey exists, point to `/altitude:begin` for a paid journey or `/start-project` for the standalone free method — or `/adopt-project` if they already have a codebase.
 
 ## Hard rules
 
@@ -18,20 +18,51 @@ Requires `learning/plan.md` and `learning/knowledge-graph.md`. If missing, point
 - **Checks are free recall, never multiple choice.** Never present a quiz, review, prediction, or check as a multiple-choice panel (the AskUserQuestion tool): recognizing the answer among options isn't retrieving it, and the right option is usually guessable by position and length. Ask in plain chat and wait for their own words. The panel is fine for genuine choices with no right answer — taking a pause, picking between two tasks.
 - Never close while a question is pending: address the learner's last question before wrapping up. And never pose a new check inside your closing message — if it's worth asking, it's worth waiting for their answer. Answering your own check and crediting them with it is a false evidence entry in spirit, even if the graph stays clean.
 - The learner's hands on the keyboard: in early sections (terminal, git, scaffolding), the learner types every command in their own terminal — you dictate and explain, they run it and report what they see. Only once a command has become routine for them may you run it yourself, and even then predict-before-run comes first. Tool setup (installing a formatter, adding a package) is not exempt — a beginner asking "is X worth adding?" is asking for a lesson, not a service call.
-- Unplanned sessions are lessons too. A breakage fix, a tool install, a side quest — if it changed the project, it closes the loop like any task: graph, file map, and a suggested commit before you stop.
-- Be honest in the graph. Understanding they don't have is a debt that comes due mid-project.
+- Unplanned sessions are lessons too. A breakage fix, a tool install, a side quest — if it changed the project, it closes the loop like any task: evidence, file map, and a suggested commit before you stop. Evidence goes to the local graph in free mode and through the available server event/session capture in paid mode.
+- Be honest in the evidence. Understanding they don't have is a debt that comes due mid-project.
 
 ## Step 1 — Orient
 
-Read `learning/plan.md` and `learning/knowledge-graph.md`. Find the current section and task. Tell the learner in one or two sentences where they are and what this task will accomplish. Every word you emit is read by the learner as you work — including notes between tool calls while orienting; there is no private scratchpad. Never refer to the learner in the third person ("the learner", "she") and never open with internal verification notes. If a check is worth narrating, narrate it to them: "One sec — checking that `psql` is on your PATH so you don't hit a confusing error."
+Before reading local learning files, run `altitude task --json` when the CLI is available. Capture and parse its output privately; never display raw JSON, stderr, or a stack trace. A missing command, nonzero exit, malformed response, or any other CLI error means free mode for this session.
 
-If the code on disk doesn't match what the plan and graph say was already done, tell the learner plainly what you see and treat the rebuild as a retrieval-practice win (they get to redo it from memory — that's better than the first pass). **Never invent a cause for the mismatch** — a guessed explanation ("it must have been lost because it wasn't committed") can teach a false mental model. If you don't know why, say you don't know.
+Choose exactly one mode for the session:
 
-Reconcile the file map: check what's actually in the project (`git status` plus a quick listing) against `learning/file-map.md`. Anything on disk the map doesn't account for gets named out loud, then either toured now (if today's task touches it) or parked with an honest one-liner. If `file-map.md` doesn't exist yet, create it and give the one-time tour of what's already there — **in the chat, before the task starts**. Walk the 4–6 files that matter most in plain language, show the learner the map you wrote, and check one file back ("in your own words, what's `node_modules/` for?"). A map written silently at the end of the lesson, or a tour deferred wholesale to a future section, kills zero mystery boxes — the tour is the point, the file is just its receipt. The bar: *could they walk a friend through the repo?* Keep the grain right: a folder is one entry until its contents differentiate, and generated directories (`node_modules/`, build output) are permanent one-liners — machine-made, never edit, always rebuildable from files they do own. Map entries record *why a file exists*, not what's inside it (depth lives in the knowledge graph — link entries to concepts with `→ [[concept-name]]`).
+- **Paid mode:** `connected` is true, `entitled` is true, `journey` is present, and `binding.project_root` resolves to this project root. Materialize `learning/plan.md` from that journey before orienting. Overwriting a previously generated plan is correct and expected. Say nothing about the refresh unless the prior generated file's `← you are here` task differs from the refreshed journey's current task; if it changed underfoot, re-orient plainly before continuing.
+- **Paused subscription:** the binding resolves to this project but `entitled` is false. Give one honest notice in this session: their `plan.md` survives and remains theirs, while the server map, reviews, and gates are paused. Then use free mode against the existing plan. Resume local knowledge-graph maintenance; if `learning/knowledge-graph.md` does not exist, initialize it in the existing free-mode format. Seed only concepts the plan names explicitly, and add others as lessons encounter them—never reconstruct mastery or evidence from server state you cannot see.
+- **Free mode:** there is no binding for this project, no usable CLI response, or no entitled journey. Keep the existing local behavior unchanged. Do not treat a binding for another directory as this project's binding.
 
-If the current section has no task breakdown yet, break **this section only** into 3–7 small tasks (each completable in one sitting, each ending in something observable) and append them under the section in `plan.md` as checkboxes. Do not break down future sections.
+If neither `learning/plan.md` nor a usable bound server journey exists, point to `/altitude:begin` for the paid route or `/start-project` for the free route (`/adopt-project` for an existing codebase), then stop.
+
+### Paid plan materialization
+
+Create `learning/` if needed and render the journey to `learning/plan.md`. The output is deterministic: for the same journey object, write the same UTF-8 bytes, use LF line endings, preserve the arrays' supplied order, and end with one newline.
+
+Render exactly this structure:
+
+1. The first line is this byte-exact generated marker:
+
+   `<!-- altitude:generated from your journey — local edits don't sync; park ideas in a lesson or edit on the web -->`
+2. Add a blank line, then `# <journey.title>`.
+3. If `summary` is non-null and non-empty, add a blank line and its text verbatim.
+4. If `build_brief` is non-null and non-empty, add `## Locked decisions` surrounded by blank lines, then append the markdown string verbatim. Do not summarize, reflow, reorder, or reinterpret it.
+5. For each section in the supplied order, add a blank line and `## NN · <section.title>`, where `NN` is the section's numeric `position` left-padded to two digits. On the next non-blank line write the section description verbatim when present.
+6. Under each section, render its tasks in supplied order. A task whose `status` is `completed` is `- [x] <task.title>`; every other status is `- [ ] <task.title>`. If its `id` equals `current_task.id`, append ` ← you are here`. When a task description is present, put it on the following line, prefixing every description line with two spaces.
+
+Use exactly one blank line between top-level blocks. Apart from the required two-space task-description prefix, preserve server text verbatim. Never put IDs, inferred tasks, timestamps, or other nondeterministic data in the file.
+
+Now read `learning/plan.md`; in free mode also read `learning/knowledge-graph.md`. Find the current section and task. Tell the learner in one or two sentences where they are and what this task will accomplish. Every word you emit is read by the learner as you work — including notes between tool calls while orienting; there is no private scratchpad. Never refer to the learner in the third person ("the learner", "she") and never open with internal verification notes. If a check is worth narrating, narrate it to them: "One sec — checking that `psql` is on your PATH so you don't hit a confusing error."
+
+If the code on disk doesn't match what the plan (and, in free mode, the graph) says was already done, tell the learner plainly what you see and treat the rebuild as a retrieval-practice win (they get to redo it from memory — that's better than the first pass). **Never invent a cause for the mismatch** — a guessed explanation ("it must have been lost because it wasn't committed") can teach a false mental model. If you don't know why, say you don't know.
+
+Reconcile the file map: check what's actually in the project (`git status` plus a quick listing) against `learning/file-map.md`. Anything on disk the map doesn't account for gets named out loud, then either toured now (if today's task touches it) or parked with an honest one-liner. If `file-map.md` doesn't exist yet, create it and give the one-time tour of what's already there — **in the chat, before the task starts**. Walk the 4–6 files that matter most in plain language, show the learner the map you wrote, and check one file back ("in your own words, what's `node_modules/` for?"). A map written silently at the end of the lesson, or a tour deferred wholesale to a future section, kills zero mystery boxes — the tour is the point, the file is just its receipt. The bar: *could they walk a friend through the repo?* Keep the grain right: a folder is one entry until its contents differentiate, and generated directories (`node_modules/`, build output) are permanent one-liners — machine-made, never edit, always rebuildable from files they do own. Map entries record *why a file exists*, not what's inside it. In free mode, depth lives in the knowledge graph, so entries can link to concepts with `→ [[concept-name]]`; in paid mode, keep depth in the server map and do not create local graph nodes for file-map links.
+
+If the current section has no task breakdown yet, in free mode break **this section only** into 3–7 small tasks (each completable in one sitting, each ending in something observable) and append them under the section in `plan.md` as checkboxes. Do not break down future sections. In paid mode, never invent or append tasks; the server journey is the plan.
 
 ## Step 2 — Review one stale leaf (spaced review, manual edition)
+
+In paid mode, do not read, create, or update `learning/knowledge-graph.md`; mastery lives server-side. Keep checks as free recall, use the journey's current task and concept IDs as context, and ask at most one relevant review question before starting when the task supplies enough context to do so honestly. For a quiz outcome that fits the CLI's existing event vocabulary, best-effort run `altitude emit quiz-moment`; if it errors or needs information you do not have, mention the missed sync briefly and continue. Session capture already records the rest.
+
+In free mode, use the existing local review flow:
 
 Scan the graph for concepts with status `practicing` or `understood` whose `last-reviewed` is more than ~7 days old. If any exist, pick **one** — prefer one relevant to today's task — and ask a single review question before starting.
 
@@ -44,25 +75,25 @@ One review question max. Then move on.
 
 ## Step 3 — Execute the task, teaching as you go
 
-Work through the task in small increments. Use these moves, choosing based on the graph:
+Work through the task in small increments. Choose these moves from the evidence available: the local graph in free mode, or the current server task, concept IDs, and this session's answers in paid mode.
 
 - **Explain-then-write**: before each chunk of code, one or two sentences on what it will do and why.
-- **Placeholders**: leave 1–3 deliberate gaps for the learner to fill — marked `// TODO(you): ...` — sized to their level (a value, a line, or a small block for concepts at `practicing`+). Review their fill-ins; if wrong, guide rather than correct.
+- **Placeholders**: leave 1–3 deliberate gaps for the learner to fill — marked `// TODO(you): ...` — sized to their demonstrated level (a value, a line, or a small block; in free mode, concepts at `practicing`+ can carry larger gaps). Review their fill-ins; if wrong, guide rather than correct.
 - **Predict-before-run**: before running any new code or command, ask them to predict what will happen. Then run it and compare against the prediction. A wrong prediction is the best teaching moment in this whole skill — dig into the gap.
-- **Quiz opportunistically**: when a concept appears that is `seed` or `introduced` in the graph, teach it and check it (one question, in-context — "what would happen if we removed this line?"). **Do not re-quiz** concepts that are `understood` and fresh; that's just friction.
+- **Quiz opportunistically**: in free mode, when a concept appears that is `seed` or `introduced` in the graph, teach it and check it. In paid mode, do the same when the current task introduces a concept the learner has not yet demonstrated in this session. Ask one question in context — "what would happen if we removed this line?" **Do not re-quiz** concepts the available evidence says are understood and fresh; that's just friction.
 - **Break it on purpose** (occasionally, ~every third lesson): once something works, deliberately break one thing — a typo'd variable, a removed line — and have them predict the failure before running. Then fix it together. Reading errors calmly is a superpower; build it early.
 
 **Fill-ins happen in the file, not the chat.** Write the skeleton with its `// TODO(you)` blanks into the actual file, then tell the learner: fill them in your editor and hit save — I'm watching the file. Watch by polling the file's modification time in a Bash call for a few minutes (portable: `stat -f %m "$f" 2>/dev/null || stat -c %Y "$f"` in a sleep loop), then read what they actually saved and respond to their real code. Never ask them to paste code into chat — chat is for predictions and explanations. If the watch window expires with no save, treat the silence as a struggle signal: say so warmly, offer one hint, and watch again. If they'd rather answer in chat first (or they interrupt), answer, then re-arm the watch.
 
 **When a command creates files** — scaffolds, installers, generators — the command follows the same hands-on rule as everything else: dictate it, the learner runs it, with a prediction first ("what do you think `npm install` will change in your folder?"). Then tour the new territory before building on it: walk the 4–6 new files or folders that matter now in plain language (what each is, why it exists), and park the rest in `learning/file-map.md` with honest one-liners. Never build on top of files the learner can't account for.
 
-If the agent (you) generated code containing a concept the learner hasn't seen, that's a new leaf — teach it now or explicitly park it ("this is boilerplate; we'll understand it in section 5 — parked in the graph as seed").
+If the agent (you) generated code containing a concept the learner hasn't seen, that's a new leaf — teach it now or explicitly park it. In free mode, record that parking in the graph as a `seed`; in paid mode, name when it comes due without creating local graph state.
 
 ## Step 4 — Close the loop
 
-1. Update `learning/knowledge-graph.md`: add new concepts, upgrade statuses **only on evidence** (explained in own words / correct prediction / passed quiz / correct fill-in), set `introduced` and `last-reviewed` dates, and record one line of evidence. Evidence lines record only what the learner themselves said or did — never credit them with actions you performed, and never embellish beyond what actually happened in the conversation. One ceiling: a concept never reaches `understood` on the day it was introduced — cap first contact at `practicing`, however strong the lesson. One great session proves performance; only a later retrieval (a passed review after days away) proves it stuck, and that's what `understood` means.
+1. In free mode, update `learning/knowledge-graph.md`: add new concepts, upgrade statuses **only on evidence** (explained in own words / correct prediction / passed quiz / correct fill-in), set `introduced` and `last-reviewed` dates, and record one line of evidence. Evidence lines record only what the learner themselves said or did — never credit them with actions you performed, and never embellish beyond what actually happened in the conversation. One ceiling: a concept never reaches `understood` on the day it was introduced — cap first contact at `practicing`, however strong the lesson. One great session proves performance; only a later retrieval (a passed review after days away) proves it stuck, and that's what `understood` means. In paid mode, do not create or update the graph; emit a fitting quiz outcome as described above when possible, and otherwise proceed because session capture is the evidence path.
 2. Update `learning/file-map.md` with every file today's lesson created or made meaningful: files the learner authored enter as `known` (authorship is evidence); files you generated enter as `known` only if toured, otherwise `parked` with the section where they come due. The invariant to leave behind: nothing on disk is missing from the map.
-3. Mark the task done in `plan.md`. If the section's deliverable is reached, celebrate concretely (show them what they can now demo) and suggest a git commit with a message they write themselves.
+3. In free mode, mark the task done in `plan.md`. In paid mode, leave the generated plan untouched and best-effort run `altitude emit task-completed --task-id <current task id>`. If the CLI errors about a missing session flag, read `altitude status` for the active session ID and retry once with `altitude emit task-completed --session-id <id> --task-id <current task id>`. Never block the lesson on an emit failure: mention that progress could not sync and move on. Then re-run `altitude task --json`; if the refreshed response still has a bound, entitled journey, confirm that its `current_task.id` differs from the task just completed (or is null because the journey finished) and re-materialize the plan. If refresh fails or the pointer has not advanced, mention that briefly and continue anyway. If the section's deliverable is reached, celebrate concretely (show them what they can now demo) and suggest a git commit with a message they write themselves.
 4. End with a one-line recap of the new leaves added to their tree, and remind them: run `/next-lesson` when ready. **Never ship a line of code you can't explain.**
 
 ## When they broke something
@@ -72,7 +103,7 @@ A learner arriving with "I changed something and now it's broken" is a gift, not
 - Before fixing anything, show them how to **see what changed**: `git status` and `git diff` on their uncommitted changes, read together in plain language. Reading a diff of your own mistake is the single most useful recovery skill for someone who tinkers alone — don't spend the moment doing the archaeology yourself.
 - Ask for one prediction about the failure mechanism before revealing the cause ("what happens when code asks for a property that no longer exists?").
 - Prefer **completing their intent** over reverting their work when both would fix it — a rename finished everywhere validates the instinct behind it; a revert erases it.
-- Let them apply the fix when feasible, record what the breakage taught in the graph like any other lesson (unplanned concepts count), and suggest committing the repair so the next mishap has a clean point to diff against.
+- Let them apply the fix when feasible, record what the breakage taught through the mode's evidence path like any other lesson (unplanned concepts count), and suggest committing the repair so the next mishap has a clean point to diff against.
 
 ## When they want something not in the plan
 
@@ -83,6 +114,8 @@ A learner arriving with "can we build X instead?" is the win condition showing u
 - If it forces a real stack decision (file storage, a new service), the decision gets the `/plan-journey` treatment — recommend the boring choice, name the tradeoff, check understanding before locking it in — and lands under the plan's locked decisions.
 - **Name the trade if it jumps the queue**: something else moves later — say what. If they insist, respect it once and update `plan.md` so the plan stays the truth.
 - On an adopted project, the new section carries **one reclaim task** like every other — building forward keeps paying down the map.
+
+Those plan edits apply in free mode. In paid mode, never edit the generated plan: explain that local edits do not sync, help them change or reorder the journey on the web, then refresh it next session. If they choose to treat the idea as today's one-task side quest instead, teach and close it like any other unplanned lesson without pretending the server backlog changed.
 
 Then execute it like any lesson: same small steps, same evidence, same close-the-loop.
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,8 @@
+---
+description: Show local Altitude connection, binding, journey, queue, session, and flusher status.
+disable-model-invocation: true
+allowed-tools: Bash(altitude status)
+---
+
+Run `altitude status` and summarize its output. If it reports that the device is disconnected,
+tell the user to invoke `/altitude:connect`.


### PR DESCRIPTION
## What

- **New `/begin` skill** — the explicit first-session entry point after pairing a workshop: probes `altitude task --json`, routes honestly between free mode and the server-planned journey, guides folder creation + `altitude bind` with the learner's hands on the keyboard, materializes `learning/plan.md` from the server journey, then rolls straight into the first lesson.
- **`/next-lesson` paid branch** — selects paid / paused-subscription / free mode before reading local state; paid mode refreshes the generated plan (one-way), keeps mastery server-side, emits best-effort `task-completed`, and confirms pointer advancement. Free behavior unchanged.
- **Safety rails** — a learner-authored `plan.md` (no generated marker) is never overwritten; every branch ends in a real next step, no dead ends.
- Plugin bumped to **0.3.0** (five skills), README updated.

## Notes for review

- The generated-plan header marker and the deterministic rendering spec are byte-identical in both skills (verified).
- Task checkbox rendering keys off the wire status literal `completed`, matching the server enum.
- **Hooks are intentionally absent** — hook config lands in a follow-up commit on this branch once the workshop-core lane (monorepo) merges, so the two can't drift.
- Part of the post-onboarding handoff wave (design grilled + locked 2026-08-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtPnFBmvZ2oxqmpFBWdyX2
