### PR TITLE
Teach in the learner's own shell instead of assuming macOS

### DIFF
--- a/skills/begin/SKILL.md
+++ b/skills/begin/SKILL.md
@@ -12,8 +12,21 @@ You are a patient senior engineer welcoming a beginner into their Altitude journ
 - Run `altitude task --json` first. Capture its output for your own routing; never print the raw JSON, stderr, or a stack trace to the learner.
 - Any missing command, nonzero exit, malformed response, or other CLI error means **free mode for this attempt**. Degrade warmly and keep going.
 - One command at a time. The learner types setup commands in their own terminal, tells you what happened, and gets an explanation before the next command.
+- Dictate every command for the platform and shell the learner is actually on. You are running on their machine, so read the host platform from your environment instead of defaulting to macOS/Linux. On Windows, run **Match their shell** below before the first setup command — detect it, never ask the learner to name a shell or install a different one. When a command you gave fails because it was wrong for their system, own it immediately and plainly — a beginner's default assumption is that they broke it, and this is their first session.
 - Never overwrite a learner-authored `learning/plan.md`. Only a plan whose first line is the exact generated marker below may be refreshed from the server.
 - Never duplicate application setup that the journey already teaches. In particular, leave `git init`, scaffolding, and project tool installation to the journey's tasks when its first section covers them.
+
+## Match their shell
+
+Read the host platform from your environment. On macOS or Linux there is nothing to do here, and you must not create the file described below.
+
+On Windows, detect the shell before dictating the first command — including `npm install -g @learnaltitude/cli` in Step 1, which for many learners is the first command they ever run. **Never ask the learner to name their shell**; someone starting their first session cannot answer that, and asking teaches them the tool expects knowledge they don't have. Never ask them to install a different one. Ask them to run `uname -s` and report what came back, framed as the first thing you're learning about their machine rather than a test:
+
+- `MINGW64_NT…` or `MSYS_NT…` → Git Bash
+- `Linux` → WSL
+- "not recognized" or any other error → Windows-native. Have them run `$PSVersionTable.PSVersion`; a version table means PowerShell, a second error means `cmd`. An error here is information, not failure — say so plainly, because their first-ever command just appeared to fail.
+
+Hold that value for the session and teach in that dialect. **Do not write it to disk yet** — the journey folder does not exist until Step 3, and creating `learning/` before then puts it in whatever directory they happened to start in. Record it in Step 4, once the project root is real.
 
 ## Step 1 — Find their route
 
@@ -71,6 +84,15 @@ Render exactly this structure:
 6. Under each section, render its tasks in supplied order. A task whose `status` is `completed` is `- [x] <task.title>`; every other status is `- [ ] <task.title>`. If its `id` equals `current_task.id`, append ` ← you are here`. When a task description is present, put it on the following line, prefixing every description line with two spaces.
 
 Use exactly one blank line between top-level blocks. Apart from the required two-space task-description prefix, preserve server text verbatim. Never put IDs, inferred tasks, timestamps, or other nondeterministic data in the file.
+
+On Windows only, also write the shell you detected earlier to `learning/environment.md`, so later sessions and `/altitude:next-lesson` don't re-detect it. Exactly these bytes, LF line endings, one trailing newline, nothing else — no dates, no IDs, no notes:
+
+```
+<!-- altitude:environment — how your lessons write commands; edit this if your setup changes -->
+
+- platform: windows
+- shell: <powershell | cmd | git-bash | wsl>
+```
 
 ## Step 5 — Point out the route, then begin
 

--- a/skills/next-lesson/SKILL.md
+++ b/skills/next-lesson/SKILL.md
@@ -18,6 +18,7 @@ Free mode requires `learning/plan.md` and `learning/knowledge-graph.md`. Paid mo
 - **Checks are free recall, never multiple choice.** Never present a quiz, review, prediction, or check as a multiple-choice panel (the AskUserQuestion tool): recognizing the answer among options isn't retrieving it, and the right option is usually guessable by position and length. Ask in plain chat and wait for their own words. The panel is fine for genuine choices with no right answer — taking a pause, picking between two tasks.
 - Never close while a question is pending: address the learner's last question before wrapping up. And never pose a new check inside your closing message — if it's worth asking, it's worth waiting for their answer. Answering your own check and crediting them with it is a false evidence entry in spirit, even if the graph stays clean.
 - The learner's hands on the keyboard: in early sections (terminal, git, scaffolding), the learner types every command in their own terminal — you dictate and explain, they run it and report what they see. Only once a command has become routine for them may you run it yourself, and even then predict-before-run comes first. Tool setup (installing a formatter, adding a package) is not exempt — a beginner asking "is X worth adding?" is asking for a lesson, not a service call.
+- **Dictate commands for the machine they're actually on.** You are running on the learner's computer, so read the host platform from your environment rather than defaulting to macOS/Linux. Windows is where this bites: PowerShell aliases `ls`, `cat`, and `pwd` so they look fine, while `touch`, `chmod`, `which`, `open`, `export VAR=`, and `rm -rf` are not there at all — a partial adaptation is worse than none, because it fails unpredictably. Windows also has several shells in play, so follow **Match their shell** in Step 1 before the first command of the journey — detect it, never ask the learner to name a shell or install a different one. When a command you dictated fails because it was wrong for their system, say so immediately and plainly — "that one's on me, it's a macOS command." A beginner's default assumption is that they broke it, and leaving that belief in place costs far more than the command did.
 - Unplanned sessions are lessons too. A breakage fix, a tool install, a side quest — if it changed the project, it closes the loop like any task: evidence, file map, and a suggested commit before you stop. Evidence goes to the local graph in free mode and through the available server event/session capture in paid mode.
 - Be honest in the evidence. Understanding they don't have is a debt that comes due mid-project.
 
@@ -32,6 +33,28 @@ Choose exactly one mode for the session:
 - **Free mode:** there is no binding for this project, no usable CLI response, or no entitled journey. Keep the existing local behavior unchanged. Do not treat a binding for another directory as this project's binding.
 
 If neither `learning/plan.md` nor a usable bound server journey exists, point to `/altitude:begin` for the paid route or `/start-project` for the free route (`/adopt-project` for an existing codebase), then stop.
+
+### Match their shell
+
+Read the host platform from your environment. On macOS or Linux there is nothing to do here — the commands this method teaches are the same in `bash` and `zsh`, and you must not create the file below.
+
+On Windows, do this before dictating any command:
+
+1. Read `learning/environment.md` if it exists. When it records a shell, teach in that dialect and do not re-detect.
+2. Otherwise detect it. **Never ask the learner to name their shell** — someone who just told you they've never used a terminal cannot answer that, and asking teaches them that the tool expects knowledge they don't have. Never ask them to install a different one either. Instead, ask them to run `uname -s` and report what came back, framed as the first thing you're learning about their machine rather than a test:
+   - `MINGW64_NT…` or `MSYS_NT…` → Git Bash
+   - `Linux` → WSL
+   - "not recognized" or any other error → Windows-native. Have them run `$PSVersionTable.PSVersion`; a version table means PowerShell, a second error means `cmd`. An error here is information, not failure — say so, because this is likely their first command and it "failed."
+3. Write `learning/environment.md`, creating `learning/` if needed. Exactly these bytes, LF line endings, one trailing newline, nothing else — no dates, no IDs, no notes:
+
+   ```
+   <!-- altitude:environment — how your lessons write commands; edit this if your setup changes -->
+
+   - platform: windows
+   - shell: <powershell | cmd | git-bash | wsl>
+   ```
+
+4. Teach in that dialect for the rest of the journey. If a later command fails in a way that contradicts the recorded shell, re-detect and rewrite the file rather than trusting it — a learner who installed WSL halfway through is a success story, not an error state.
 
 ### Paid plan materialization
 
@@ -83,7 +106,7 @@ Work through the task in small increments. Choose these moves from the evidence 
 - **Quiz opportunistically**: in free mode, when a concept appears that is `seed` or `introduced` in the graph, teach it and check it. In paid mode, do the same when the current task introduces a concept the learner has not yet demonstrated in this session. Ask one question in context — "what would happen if we removed this line?" **Do not re-quiz** concepts the available evidence says are understood and fresh; that's just friction.
 - **Break it on purpose** (occasionally, ~every third lesson): once something works, deliberately break one thing — a typo'd variable, a removed line — and have them predict the failure before running. Then fix it together. Reading errors calmly is a superpower; build it early.
 
-**Fill-ins happen in the file, not the chat.** Write the skeleton with its `// TODO(you)` blanks into the actual file, then tell the learner: fill them in your editor and hit save — I'm watching the file. Watch by polling the file's modification time in a Bash call for a few minutes (portable: `stat -f %m "$f" 2>/dev/null || stat -c %Y "$f"` in a sleep loop), then read what they actually saved and respond to their real code. Never ask them to paste code into chat — chat is for predictions and explanations. If the watch window expires with no save, treat the silence as a struggle signal: say so warmly, offer one hint, and watch again. If they'd rather answer in chat first (or they interrupt), answer, then re-arm the watch.
+**Fill-ins happen in the file, not the chat.** Write the skeleton with its `// TODO(you)` blanks into the actual file, then tell the learner: fill them in your editor and hit save — I'm watching the file. Watch by polling the file's modification time from a shell call for a few minutes, using a command that exists on their system — macOS/Linux: `stat -f %m "$f" 2>/dev/null || stat -c %Y "$f"` in a sleep loop; PowerShell: `(Get-Item "$f").LastWriteTime.Ticks` with `Start-Sleep` (`stat` does not exist there at all). Then read what they actually saved and respond to their real code. Never ask them to paste code into chat — chat is for predictions and explanations. If the watch window expires with no save, treat the silence as a struggle signal: say so warmly, offer one hint, and watch again — but only after confirming your own poll command ran successfully. A polling command that errors every iteration is indistinguishable from a learner who typed nothing, and recording that as a struggle is a false evidence entry. If they'd rather answer in chat first (or they interrupt), answer, then re-arm the watch.
 
 **When a command creates files** — scaffolds, installers, generators — the command follows the same hands-on rule as everything else: dictate it, the learner runs it, with a prediction first ("what do you think `npm install` will change in your folder?"). Then tour the new territory before building on it: walk the 4–6 new files or folders that matter now in plain language (what each is, why it exists), and park the rest in `learning/file-map.md` with honest one-liners. Never build on top of files the learner can't account for.
 


### PR DESCRIPTION
## What

Terminal lessons dictated macOS/bash commands regardless of the learner's OS. Nothing in the skills adapted for platform — no mention of Windows, PowerShell, or WSL anywhere in the repo.

The generated journey is command-free (it specifies outcomes, not commands), so the actual commands are improvised at lesson time and defaulted to macOS. On Windows that lands in section 1, on a learner who just said they've never used a terminal, whose default assumption is that they broke it.

## Changes

- **`next-lesson` + `begin` read the host platform** and dictate commands for it. Windows detection is a lesson beat, not a question: one `uname -s` the learner runs and reports, plus one follow-up probe to split PowerShell from `cmd`. Never ask a beginner to name their shell; never ask them to install a different one.
- **The Windows-native branch returns "not recognized"** for their first-ever command, so both skills require naming that as information rather than failure before moving on.
- **The shell persists in `learning/environment.md`**, spec'd byte-exactly like `plan.md`'s marker so both writers agree. Created on Windows only — existing learners see no new file. A later contradiction re-detects rather than trusting the file.
- **`begin` detects early but writes in step 4** — the journey folder doesn't exist until step 3, so writing at detection time would drop `learning/` in whatever directory they launched from.
- **Fixes the fill-in watch loop**, which polled with `stat` — absent from PowerShell entirely. It errored every iteration on Windows, and the next rule read that silence as a struggle signal, logging false evidence against a learner who had filled the blanks in correctly.

## Verification

Unverified on Windows: the authoring machine is macOS and this repo has no test harness. The detection ladder is reasoned, not observed. Confirmed by hand: both `environment.md` specs are byte-identical, no contradictory wording survives, the adapters vendor only `connect`/`status` so there's no second copy to sync, and `next-lesson` only reaches detection after its existing bail-out for projects with no plan.

The highest-value next step is one real Windows learner session — specifically whether their `uname -s` output matches one of the three branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWWPArFfVhQ1PT3tbcCBjh