### PR TITLE
Serve altitude-skills as a Codex plugin alongside Claude Code

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "name": "altitude",
+  "plugins": [
+    {
+      "name": "altitude",
+      "source": ".",
+      "description": "Learn to code by building a real project with an AI coding agent — seven skills that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "altitude",
   "description": "Learn to code by building a real project with an AI coding agent \u2014 seven skills (begin, start-project, plan-journey, next-lesson, adopt-project, connect, status) plus dormant-by-default session hooks that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Jason Ku"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "altitude",
+  "version": "0.5.0",
+  "description": "Learn to code by building a real project with an AI coding agent — seven skills (begin, start-project, plan-journey, next-lesson, adopt-project, connect, status) plus dormant-by-default session hooks that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
+  "hooks": "./hooks/codex.json",
+  "keywords": [
+    "learn-to-code",
+    "education",
+    "beginner",
+    "skills",
+    "knowledge-graph"
+  ],
+  "interface": {
+    "displayName": "Altitude",
+    "shortDescription": "Learn to code by building — with session capture and learning gates",
+    "longDescription": "Turns your coding agent into a tutor instead of a ghostwriter. Seven skills walk you from project idea to deployed MVP one fully-understood step at a time; with a subscribed Altitude journey, dormant-by-default hooks capture session evidence and run the learning gates.",
+    "developerName": "Altitude",
+    "category": "Education",
+    "capabilities": [
+      "Hooks"
+    ],
+    "defaultPrompt": [
+      "Connect this Codex installation to Altitude.",
+      "Show my local Altitude workshop status."
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/README.md
+++ b/README.md
@@ -39,14 +39,23 @@ The free method is complete and works standalone: `/start-project` + `/plan-jour
 
 ## Install
 
-**As a plugin** (Claude Code only — recommended there, since it updates with the repo):
+**As a plugin** (recommended — it updates with the repo). In Claude Code, type both lines inside the agent:
 
 ```
 /plugin marketplace add jasonku09/altitude-skills
 /plugin install altitude@altitude
 ```
 
-**Or copy the skills directly:**
+In Codex, run both lines in your terminal:
+
+```bash
+codex plugin marketplace add jasonku09/altitude-skills
+codex plugin add altitude@altitude
+```
+
+The first `codex` launch after installing shows a one-time "Hooks need review" prompt — choose **Trust all and continue** to enable Altitude's session hooks. (They stay dormant outside bound journey projects; see below.)
+
+**Or copy the skills directly** (Claude Code):
 
 ```bash
 git clone https://github.com/jasonku09/altitude-skills.git
@@ -57,12 +66,11 @@ For the standalone method, open a new Claude Code session in an empty folder and
 
 The plugin also bundles Altitude's session hooks (`hooks/`). They stay fully dormant unless you're working inside a project bound to a subscribed journey (`altitude bind` / `/altitude:begin`) — no events, gates, or context injection anywhere else. With a bound project, they capture session evidence for your journey and run the plan/diff/retro gates. Gates fail open: a crashed hook never blocks your work. The `/altitude:connect` and `/altitude:status` skills manage the link.
 
-**Using Codex or Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which both support — only the target folder changes:
+**Using Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which Cursor supports — copy them in:
 
 ```bash
 git clone https://github.com/jasonku09/altitude-skills.git
-cp -r altitude-skills/skills/* ~/.codex/skills/    # Codex (invoke with $start-project, or /skills to list)
-cp -r altitude-skills/skills/* ~/.cursor/skills/   # Cursor (pick via / in Agent chat, or automatic)
+cp -r altitude-skills/skills/* ~/.cursor/skills/   # pick via / in Agent chat, or automatic
 ```
 
 Copied skills don't auto-update — re-run the clone + copy to pick up new versions. And [PROMPTS.md](PROMPTS.md) works with any agent at all, no install needed.

--- a/bin/altitude-codex-hook.mjs
+++ b/bin/altitude-codex-hook.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// Codex hook shim. hooks/codex.json invokes this file through frozen
+// `${PLUGIN_ROOT}` one-liners whose raw text Codex's hook-trust hash covers —
+// so all logic that may need to change lives here, where edits never
+// re-prompt (or silently drop) a user's trust.
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const mappingPath = join(pluginRoot, "hooks/codex-field-mapping.json");
+
+const hookActions = {
+  "session-start": [
+    "hook",
+    "session-start",
+    "--agent",
+    "codex",
+    "--mapping",
+    mappingPath,
+    "--print-context",
+    "--nudge",
+    "Run $next-lesson to continue (or $begin for your first session).",
+  ],
+  plan: [
+    "hook",
+    "pre-tool-use",
+    "--agent",
+    "codex",
+    "--mapping",
+    mappingPath,
+    "--gate",
+    "plan",
+  ],
+  diff: [
+    "hook",
+    "pre-tool-use",
+    "--agent",
+    "codex",
+    "--mapping",
+    mappingPath,
+    "--gate",
+    "diff",
+  ],
+  stop: [
+    "hook",
+    "stop",
+    "--agent",
+    "codex",
+    "--mapping",
+    mappingPath,
+    "--gate",
+    "retro",
+  ],
+};
+
+function executable(name) {
+  return process.platform === "win32" ? `${name}.cmd` : name;
+}
+
+function run(command, args, options = {}) {
+  return spawnSync(executable(command), args, {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+    ...options,
+  });
+}
+
+async function runHook(action) {
+  let stdin = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) stdin += chunk;
+
+  const result = run("altitude", hookActions[action], { input: stdin });
+  if (result.error) {
+    // Gates fail OPEN: a missing or crashed CLI must never block the session.
+    process.stderr.write(
+      `Altitude could not run the workshop CLI: ${result.error.message}\n`,
+    );
+    return 0;
+  }
+
+  if (result.stderr) process.stderr.write(result.stderr);
+  // Plain stdout passthrough for every action: Codex injects non-JSON
+  // SessionStart stdout as model context (the Claude Code convention), and
+  // gate passes print nothing.
+  if (result.stdout) process.stdout.write(result.stdout);
+  return result.status ?? 0;
+}
+
+const action = process.argv[2];
+if (Object.hasOwn(hookActions, action)) {
+  process.exitCode = await runHook(action);
+} else {
+  process.stderr.write("usage: altitude-codex-hook <session-start|plan|diff|stop>\n");
+  process.exitCode = 1;
+}

--- a/hooks/codex-field-mapping.json
+++ b/hooks/codex-field-mapping.json
@@ -1,0 +1,8 @@
+{
+  "fields": {
+    "session_id": "session_id",
+    "cwd": "cwd",
+    "tool_name": "tool_name",
+    "last_assistant_message": "last_assistant_message"
+  }
+}

--- a/hooks/codex.json
+++ b/hooks/codex.json
@@ -1,0 +1,57 @@
+{
+  "description": "Altitude workshop lifecycle and learning gates.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" session-start",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" session-start",
+            "timeout": 30,
+            "statusMessage": "Starting Altitude workshop capture"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^update_plan$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" plan",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" plan",
+            "timeout": 30,
+            "statusMessage": "Checking the Altitude plan gate"
+          }
+        ]
+      },
+      {
+        "matcher": "^(apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" diff",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" diff",
+            "timeout": 30,
+            "statusMessage": "Checking the Altitude diff gate"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" stop",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" stop",
+            "timeout": 30,
+            "statusMessage": "Checking the Altitude retro gate"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "altitude-skills",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/skills/connect/SKILL.md
+++ b/skills/connect/SKILL.md
@@ -1,13 +1,20 @@
 ---
-description: Connect this Claude Code installation to the user's Altitude account.
-disable-model-invocation: true
-allowed-tools: Bash(claude --version) Bash(altitude connect *) Bash(altitude status)
+name: connect
+description: Connect this coding agent installation to the user's Altitude account via the device pairing flow.
+allowed-tools: Bash(claude --version) Bash(codex --version) Bash(altitude connect *) Bash(altitude status)
 ---
 
-Connect the current Claude Code installation to Altitude:
+Connect the current coding agent installation to Altitude:
 
-1. Run `claude --version` and take the leading semantic version number.
-2. Start `altitude connect --agent claude-code --agent-version <version> --next-hint "Open your coding agent in your project folder and run /altitude:begin to start your first lesson."` in the background.
+1. Identify which agent you are running in, then capture its version:
+   - **Claude Code:** run `claude --version` and take the leading semantic version number.
+   - **Codex:** run `codex --version` and take the version from its `codex-cli x.y.z` output.
+     If it is older than 0.131.0, warn the user that Altitude's session hooks need Codex
+     CLI >= 0.131.0 and suggest updating first — the server makes the final call during
+     pairing.
+2. Start the pairing command for your agent in the background:
+   - **Claude Code:** `altitude connect --agent claude-code --agent-version <version> --next-hint "Open your coding agent in your project folder and run /altitude:begin to start your first lesson."`
+   - **Codex:** `altitude connect --agent codex --agent-version <version> --next-hint "Open your coding agent in your project folder and run $begin to start your first lesson."`
 3. Relay the verification URL and one-time code from its output to the user immediately.
 4. Wait for the user to confirm in the browser, then report whether the command completed successfully.
 5. Run `altitude status` and summarize the connection, binding, and journey state.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,8 +1,8 @@
 ---
+name: status
 description: Show local Altitude connection, binding, journey, queue, session, and flusher status.
-disable-model-invocation: true
 allowed-tools: Bash(altitude status)
 ---
 
 Run `altitude status` and summarize its output. If it reports that the device is disconnected,
-tell the user to invoke `/altitude:connect`.
+tell the user to run the connect skill (`/altitude:connect` in Claude Code, `$connect` in Codex).

--- a/test/claude-plugin.test.mjs
+++ b/test/claude-plugin.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(join(repoRoot, relativePath), "utf8"));
+}
+
+test("ships a valid, discoverable Claude Code plugin manifest", async () => {
+  const manifest = await readJson(".claude-plugin/plugin.json");
+
+  assert.equal(manifest.name, "altitude");
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(manifest.description.length > 0, true);
+  assert.equal(
+    Object.hasOwn(manifest, "hooks"),
+    false,
+    "default hooks/hooks.json is auto-discovered; listing it loads the same file twice",
+  );
+  assert.equal(
+    Object.hasOwn(manifest, "skills"),
+    false,
+    "default skills/ is auto-discovered without a custom component path",
+  );
+});
+
+test("ships a Claude Code marketplace manifest serving this repo as the plugin root", async () => {
+  const marketplace = await readJson(".claude-plugin/marketplace.json");
+
+  assert.equal(marketplace.name, "altitude");
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, "altitude");
+  assert.equal(marketplace.plugins[0].source, "./");
+});
+
+test("declares Claude's documented payload fields without leaking them into core", async () => {
+  const mapping = await readJson("hooks/field-mapping.json");
+
+  // This file ships in the marketplace plugin, which auto-updates ahead of the
+  // learner's CLI. Every field here must be one the OLDEST CLI still in the
+  // wild understands: CLIs at or below 0.3.0 reject a mapping outright if it
+  // carries a field they do not know, which silently disables every hook.
+  assert.deepEqual(mapping, {
+    fields: {
+      session_id: "session_id",
+      cwd: "cwd",
+      tool_name: "tool_name",
+      last_assistant_message: "last_assistant_message",
+    },
+  });
+});
+
+test("wires lifecycle and gate hooks to stable exec-form core CLI invocations", async () => {
+  const config = await readJson("hooks/hooks.json");
+  const mappingPath = "${CLAUDE_PLUGIN_ROOT}/hooks/field-mapping.json";
+  const expectedBase = ["--agent", "claude-code", "--mapping", mappingPath];
+
+  assert.deepEqual(config, {
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: [
+                "hook",
+                "session-start",
+                ...expectedBase,
+                "--print-context",
+                "--nudge",
+                "Run /altitude:next-lesson to continue (or /altitude:begin if this is your first session).",
+              ],
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: "ExitPlanMode",
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: ["hook", "pre-tool-use", ...expectedBase, "--gate", "plan"],
+              timeout: 30,
+            },
+          ],
+        },
+        {
+          matcher: "Write|Edit",
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: ["hook", "pre-tool-use", ...expectedBase, "--gate", "diff"],
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      Stop: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: ["hook", "stop", ...expectedBase, "--gate", "retro"],
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      SessionEnd: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: ["hook", "session-end", ...expectedBase],
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: "altitude",
+              args: ["hook", "user-prompt-submit", ...expectedBase],
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+    },
+  });
+});
+
+test("keeps session liveness off the per-tool-call path", async () => {
+  const config = await readJson("hooks/hooks.json");
+
+  // PostToolUse fires on EVERY tool call; SessionStart + UserPromptSubmit +
+  // Stop already cover liveness without a per-tool CLI process spawn.
+  assert.equal(Object.hasOwn(config.hooks, "PostToolUse"), false);
+  assert.deepEqual(
+    Object.keys(config.hooks).sort(),
+    ["PreToolUse", "SessionEnd", "SessionStart", "Stop", "UserPromptSubmit"],
+  );
+});
+
+test("ships one connect skill that serves both agents", async () => {
+  const connect = await readFile(join(repoRoot, "skills/connect/SKILL.md"), "utf8");
+
+  assert.match(connect, /^---\n/);
+  assert.match(connect, /^name: connect$/m);
+  assert.doesNotMatch(
+    connect,
+    /disable-model-invocation/,
+    "the model may invoke connect itself (e.g. offering to reconnect a dropped device)",
+  );
+  assert.match(connect, /altitude connect --agent claude-code/);
+  assert.match(connect, /altitude connect --agent codex/);
+  assert.match(connect, /claude --version/);
+  assert.match(connect, /codex --version/);
+  assert.match(connect, /--next-hint/);
+  // Each agent's begin command, in its own invocation form.
+  assert.match(connect, /\/altitude:begin/);
+  assert.match(connect, /\$begin/);
+});
+
+test("ships one status skill that serves both agents", async () => {
+  const status = await readFile(join(repoRoot, "skills/status/SKILL.md"), "utf8");
+
+  assert.match(status, /^---\n/);
+  assert.match(status, /^name: status$/m);
+  assert.doesNotMatch(status, /disable-model-invocation/);
+  assert.match(status, /altitude status/);
+  // Points the user at the right connect invocation for either agent.
+  assert.match(status, /\/altitude:connect/);
+  assert.match(status, /\$connect/);
+});
+
+test("keeps the Claude adapter surface free of server-owned teaching content", async () => {
+  const distributable = [
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+    "hooks/field-mapping.json",
+    "hooks/hooks.json",
+    "skills/connect/SKILL.md",
+    "skills/status/SKILL.md",
+  ];
+  const forbidden = [
+    /what(?:'s| is) missing from this plan/i,
+    /walk through the diff/i,
+    /planted bug/i,
+    /two-minute retro/i,
+    /quiz before moving on/i,
+  ];
+
+  for (const relativePath of distributable) {
+    const contents = await readFile(join(repoRoot, relativePath), "utf8");
+    for (const pattern of forbidden) {
+      assert.doesNotMatch(contents, pattern, `${relativePath} contains server-owned content`);
+    }
+  }
+});

--- a/test/codex-plugin.test.mjs
+++ b/test/codex-plugin.test.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, delimiter, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const shim = join(repoRoot, "bin/altitude-codex-hook.mjs");
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(join(repoRoot, relativePath), "utf8"));
+}
+
+async function fakeExecutable(directory, name, body) {
+  const path = join(directory, name);
+  await writeFile(path, `#!/bin/sh\n${body}\n`);
+  await chmod(path, 0o755);
+  return path;
+}
+
+function runShim(args, options = {}) {
+  return spawnSync(process.execPath, [shim, ...args], {
+    encoding: "utf8",
+    ...options,
+    env: {
+      ...process.env,
+      ...options.env,
+    },
+  });
+}
+
+test("ships a Codex marketplace manifest that serves this repo as its own plugin root", async () => {
+  const marketplace = await readJson(".agents/plugins/marketplace.json");
+
+  assert.equal(marketplace.name, "altitude");
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, "altitude");
+  // "." resolves to the marketplace root itself (codex marketplace.rs), so the
+  // repo root doubles as the plugin root for both agents.
+  assert.equal(marketplace.plugins[0].source, ".");
+});
+
+test("ships a Codex plugin manifest pointing hooks at the Codex-specific file", async () => {
+  const manifest = await readJson(".codex-plugin/plugin.json");
+
+  assert.equal(manifest.name, "altitude");
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(manifest.description.length > 0, true);
+  // Codex requires manifest resource paths to start with "./" and SILENTLY
+  // ignores them otherwise, falling back to hooks/hooks.json — the Claude
+  // file, whose exec-form `args` Codex drops. This exact string is
+  // load-bearing.
+  assert.equal(manifest.hooks, "./hooks/codex.json");
+  assert.equal(
+    Object.hasOwn(manifest, "skills"),
+    false,
+    "default skills/ is auto-discovered without a manifest override",
+  );
+});
+
+test("keeps the two plugin manifests on the same released version", async () => {
+  const codex = await readJson(".codex-plugin/plugin.json");
+  const claude = await readJson(".claude-plugin/plugin.json");
+
+  assert.equal(codex.version, claude.version);
+});
+
+test("declares Codex's documented hook payload fields at the adapter edge", async () => {
+  const mapping = await readJson("hooks/codex-field-mapping.json");
+
+  assert.deepEqual(mapping, {
+    fields: {
+      session_id: "session_id",
+      cwd: "cwd",
+      tool_name: "tool_name",
+      last_assistant_message: "last_assistant_message",
+    },
+  });
+});
+
+test("wires lifecycle and PreToolUse gates through frozen cross-platform shim commands", async () => {
+  const config = await readJson("hooks/codex.json");
+  const command = (action) => `node "$PLUGIN_ROOT/bin/altitude-codex-hook.mjs" ${action}`;
+  const commandWindows = (action) =>
+    `node "%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs" ${action}`;
+  const hook = (action, statusMessage) => ({
+    type: "command",
+    command: command(action),
+    commandWindows: commandWindows(action),
+    timeout: 30,
+    statusMessage,
+  });
+
+  // Codex's hook-trust hash covers exactly this handler config (raw command
+  // strings, pre-expansion), keyed by event + POSITION. Any change to a
+  // command string silently un-trusts the hook for every installed user, and
+  // reordering entries orphans their trust state. Treat this deepEqual as the
+  // freeze: iterate inside the shim, never here.
+  assert.deepEqual(config, {
+    description: "Altitude workshop lifecycle and learning gates.",
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [hook("session-start", "Starting Altitude workshop capture")],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: "^update_plan$",
+          hooks: [hook("plan", "Checking the Altitude plan gate")],
+        },
+        {
+          matcher: "^(apply_patch|Edit|Write)$",
+          hooks: [hook("diff", "Checking the Altitude diff gate")],
+        },
+      ],
+      Stop: [
+        {
+          hooks: [hook("stop", "Checking the Altitude retro gate")],
+        },
+      ],
+    },
+  });
+  assert.equal(Object.hasOwn(config.hooks, "PostToolUse"), false);
+});
+
+test("the shim forwards exact lifecycle arguments and stdin to workshop-core", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-forward-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  const argvPath = join(temp, "argv");
+  const stdinPath = join(temp, "stdin");
+  await fakeExecutable(
+    temp,
+    "altitude",
+    `printf '%s\\n' "$@" > "${argvPath}"\ncat > "${stdinPath}"`,
+  );
+  const payload = JSON.stringify({
+    session_id: "codex-session-123",
+    cwd: "/tmp/project",
+    hook_event_name: "PreToolUse",
+    tool_name: "apply_patch",
+    tool_input: { patch: "*** Begin Patch" },
+  });
+
+  const result = runShim(["diff"], {
+    input: payload,
+    env: { PATH: `${temp}${delimiter}${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "");
+  assert.deepEqual((await readFile(argvPath, "utf8")).trim().split("\n"), [
+    "hook",
+    "pre-tool-use",
+    "--agent",
+    "codex",
+    "--mapping",
+    join(repoRoot, "hooks/codex-field-mapping.json"),
+    "--gate",
+    "diff",
+  ]);
+  assert.equal(await readFile(stdinPath, "utf8"), payload);
+});
+
+test("the shim preserves exit 2 and the gate reason", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-block-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  await fakeExecutable(temp, "altitude", 'echo "server-authored gate reason" >&2\nexit 2');
+
+  const result = runShim(["plan"], {
+    input: JSON.stringify({ session_id: "codex-block" }),
+    env: { PATH: `${temp}${delimiter}${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /server-authored gate reason/);
+});
+
+test("SessionStart passes core context through as plain stdout for model injection", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-context-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  await fakeExecutable(
+    temp,
+    "altitude",
+    "printf 'Altitude journey: Foundations\\nCurrent task: Ship the adapter\\n'",
+  );
+
+  const result = runShim(["session-start"], {
+    input: JSON.stringify({ session_id: "codex-context" }),
+    env: { PATH: `${temp}${delimiter}${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 0);
+  // Codex injects non-JSON SessionStart stdout as additional context for the
+  // MODEL (session_start.rs) — the same convention Claude Code uses. Wrapping
+  // it in {systemMessage} instead would show the text to the user while the
+  // model never sees the journey state.
+  assert.equal(
+    result.stdout,
+    "Altitude journey: Foundations\nCurrent task: Ship the adapter\n",
+  );
+});
+
+test("SessionStart supplies a Codex-form ($skill) lesson nudge", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-nudge-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  const argvPath = join(temp, "argv");
+  await fakeExecutable(temp, "altitude", `printf '%s\\n' "$@" > "${argvPath}"`);
+
+  const result = runShim(["session-start"], {
+    input: JSON.stringify({ session_id: "codex-nudge", cwd: "/tmp/project" }),
+    env: { PATH: `${temp}${delimiter}${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 0);
+  const argv = (await readFile(argvPath, "utf8")).trim().split("\n");
+  assert.deepEqual(argv.slice(-2), [
+    "--nudge",
+    "Run $next-lesson to continue (or $begin for your first session).",
+  ]);
+});
+
+test("the shim fails open when workshop-core is missing entirely", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-missing-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+
+  // PATH with no `altitude` at all: the spawn fails, the hook must not block.
+  const result = runShim(["diff"], {
+    input: JSON.stringify({ session_id: "codex-missing" }),
+    env: { PATH: temp },
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /Altitude could not run/);
+});
+
+test("the shim is hooks-only: connect and status are not shim actions", () => {
+  for (const retired of ["connect", "status"]) {
+    const result = runShim([retired], { input: "" });
+    assert.equal(result.status, 1, retired);
+    assert.match(result.stderr, /usage: altitude-codex-hook/);
+  }
+  execFileSync(process.execPath, ["--check", shim]);
+});
+
+test("keeps the Codex adapter surface free of server-owned teaching content", async () => {
+  const distributable = [
+    ".codex-plugin/plugin.json",
+    ".agents/plugins/marketplace.json",
+    "bin/altitude-codex-hook.mjs",
+    "hooks/codex-field-mapping.json",
+    "hooks/codex.json",
+  ];
+  const forbidden = [
+    /what(?:'s| is) missing from this plan/i,
+    /walk through the diff/i,
+    /planted bug/i,
+    /two-minute retro/i,
+    /quiz before moving on/i,
+  ];
+
+  for (const relativePath of distributable) {
+    const contents = await readFile(join(repoRoot, relativePath), "utf8");
+    for (const pattern of forbidden) {
+      assert.doesNotMatch(contents, pattern, `${relativePath} contains server-owned content`);
+    }
+  }
+});
+
+test("README installs Codex through the marketplace, not clone-and-copy", async () => {
+  const readme = await readFile(join(repoRoot, "README.md"), "utf8");
+
+  assert.match(readme, /codex plugin marketplace add jasonku09\/altitude-skills/);
+  assert.match(readme, /codex plugin add altitude@altitude/);
+  assert.match(readme, /Trust all and continue/);
+  assert.doesNotMatch(
+    readme,
+    /~\/\.codex\/skills/,
+    "the Codex clone-and-copy path is retired; the plugin is the only documented install",
+  );
+});


### PR DESCRIPTION
Implements the locked layout from the Codex lane design: the repo root doubles as the plugin root for **both** agents, making this repo the single source of truth for all distributed client content.

## What's new
- **`.agents/plugins/marketplace.json` + `.codex-plugin/plugin.json`** — Codex installs via `codex plugin marketplace add jasonku09/altitude-skills` + `codex plugin add altitude@altitude`, mirroring the Claude Code marketplace path. The manifest pins hooks to `"./hooks/codex.json"`; the `./` prefix is load-bearing (Codex silently ignores the path otherwise and falls back to the Claude hooks file, whose exec-form `args` it drops).
- **`hooks/codex.json`** — frozen `${PLUGIN_ROOT}` one-liners. Codex's hook-trust hash covers exactly these raw command strings (position-keyed), so the test suite deepEquals the whole file: iterate in the shim, never here.
- **`bin/altitude-codex-hook.mjs`** — hooks-only shim (connect/status now live in the shared skills), `$next-lesson`/`$begin` nudge, and **plain stdout passthrough**: Codex injects non-JSON SessionStart stdout as *model* context (same convention as Claude Code). The previous `{systemMessage}` wrapping displayed the journey state to the user while the model never saw it — a real tutor-parity bug, fixed here with a pinning test.
- **Shared `connect`/`status` skills** — one skill per flow serving both agents; `name:` added, `disable-model-invocation` dropped, soft Codex >= 0.131.0 pre-flight in copy (server-side enforcement lands with the X0 min-version follow-up).
- **README** — Codex section switches to the marketplace install with the one-time "Hooks need review → Trust all and continue" step; clone-and-copy retired for Codex (kept for Cursor).
- **`test/`** — the adapter test suites migrated from the monorepo packages onto plain `node --test`, including a cross-manifest version-match guard.

## Evidence
- `node --test`: **21/21 green**.
- Real `codex plugin add` (0.145.0) against this branch in an isolated `CODEX_HOME`: installs `altitude@altitude` 0.5.0 from `.codex-plugin`, SessionStart/PreToolUse/Stop wired from `hooks/codex.json`, `$PLUGIN_ROOT` expands to the version-pathed cache root, and the shim forwarded exact argv + payload to a fake `altitude` CLI.
- Live `codex exec` turn: asked the model for its current Altitude task; it answered with the exact task string served through the hook — context injection proven end to end. Stop reports **Completed** on pass (exit 0, empty stdout) and the block contract (exit 2 + stderr → continuation prompt) matches the Codex source.

Companion monorepo PR (deleting `packages/adapter-*` + the copied-install machinery) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkUXAThDiLWkB2LyoTuAsv