### PR TITLE
fix(hooks): map the learner's prompt through to answer capture

### DIFF
--- a/hooks/field-mapping.json
+++ b/hooks/field-mapping.json
@@ -3,6 +3,7 @@
     "session_id": "session_id",
     "cwd": "cwd",
     "tool_name": "tool_name",
+    "prompt": "prompt",
     "last_assistant_message": "last_assistant_message"
   }
 }

--- a/test/claude-plugin.test.mjs
+++ b/test/claude-plugin.test.mjs
@@ -42,13 +42,18 @@ test("declares Claude's documented payload fields without leaking them into core
 
   // This file ships in the marketplace plugin, which auto-updates ahead of the
   // learner's CLI. Every field here must be one the OLDEST CLI still in the
-  // wild understands: CLIs at or below 0.3.0 reject a mapping outright if it
-  // carries a field they do not know, which silently disables every hook.
+  // wild understands. That floor is 0.4.0: from 0.4.0 the CLI drops unknown
+  // mapping fields instead of rejecting the mapping (which on ≤0.3.0 silently
+  // disables every hook), and the server's agent-version floor at device
+  // connect is how any straggler gets pushed forward. `prompt` requires
+  // ≥0.4.0 and is what answer capture rides on — without it the hook never
+  // sees the learner's reply to a parked retro question.
   assert.deepEqual(mapping, {
     fields: {
       session_id: "session_id",
       cwd: "cwd",
       tool_name: "tool_name",
+      prompt: "prompt",
       last_assistant_message: "last_assistant_message",
     },
   });


### PR DESCRIPTION
The single-source migration (#8) snapshotted `hooks/field-mapping.json` from before the CLI's answer-capture release, dropping the `prompt` mapping that `user-prompt-submit` needs to answer a parked retro question. The hook fails open, so nothing crashed — answer capture was just silently inert for every learner.

The guard test's old comment held this file to fields a ≤0.3.0 CLI understands (those CLIs reject a mapping with any unknown field, disabling every hook). That floor is obsolete:

- CLI ≥0.4.0 **drops** unknown mapping fields by design (`parseHookPayload` in workshop-core) — a newer plugin than the CLI is the documented normal case.
- The server's agent-version floor at device connect is the mechanism for pushing stragglers forward.
- Pre-beta, no ≤0.3.0 CLI exists in the wild.

One line in the mapping; the guard test now pins the new five-field shape and documents the ≥0.4.0 floor policy. `npm test` 21/21 green (red-first verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01441McV3RBjfR3wWKyTzKpC