### PR TITLE
fix(codex): wire SessionEnd and UserPromptSubmit to match Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "altitude",
   "description": "Learn to code by building a real project with an AI coding agent \u2014 seven skills (begin, start-project, plan-journey, next-lesson, adopt-project, connect, status) plus dormant-by-default session hooks that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Jason Ku"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "altitude",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Learn to code by building a real project with an AI coding agent — seven skills (begin, start-project, plan-journey, next-lesson, adopt-project, connect, status) plus dormant-by-default session hooks that enforce small steps, predict-before-run, and evidence-based reviews. Never ship a line you can't explain.",
   "hooks": "./hooks/codex.json",
   "keywords": [

--- a/bin/altitude-codex-hook.mjs
+++ b/bin/altitude-codex-hook.mjs
@@ -54,6 +54,19 @@ const hookActions = {
     "--gate",
     "retro",
   ],
+  // Stop is end of TURN. Only this lifecycle ends the session, so without it
+  // the session marker is never retired and no `session_ended` is ever sent.
+  "session-end": ["hook", "session-end", "--agent", "codex", "--mapping", mappingPath],
+  // Turn start: stamps what this turn's gates credit, and carries the
+  // learner's answer to a retro question parked at the end of the last turn.
+  "user-prompt-submit": [
+    "hook",
+    "user-prompt-submit",
+    "--agent",
+    "codex",
+    "--mapping",
+    mappingPath,
+  ],
 };
 
 function executable(name) {
@@ -94,6 +107,9 @@ const action = process.argv[2];
 if (Object.hasOwn(hookActions, action)) {
   process.exitCode = await runHook(action);
 } else {
-  process.stderr.write("usage: altitude-codex-hook <session-start|plan|diff|stop>\n");
+  process.stderr.write(
+    "usage: altitude-codex-hook " +
+      "<session-start|plan|diff|stop|session-end|user-prompt-submit>\n",
+  );
   process.exitCode = 1;
 }

--- a/hooks/codex-field-mapping.json
+++ b/hooks/codex-field-mapping.json
@@ -3,6 +3,7 @@
     "session_id": "session_id",
     "cwd": "cwd",
     "tool_name": "tool_name",
+    "prompt": "prompt",
     "last_assistant_message": "last_assistant_message"
   }
 }

--- a/hooks/codex.json
+++ b/hooks/codex.json
@@ -52,6 +52,32 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" session-end",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" session-end",
+            "timeout": 30,
+            "statusMessage": "Closing the Altitude workshop session"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$PLUGIN_ROOT/bin/altitude-codex-hook.mjs\" user-prompt-submit",
+            "commandWindows": "node \"%PLUGIN_ROOT%\\bin\\altitude-codex-hook.mjs\" user-prompt-submit",
+            "timeout": 30,
+            "statusMessage": "Recording your Altitude turn"
+          }
+        ]
+      }
     ]
   }
 }

--- a/test/codex-plugin.test.mjs
+++ b/test/codex-plugin.test.mjs
@@ -75,6 +75,10 @@ test("declares Codex's documented hook payload fields at the adapter edge", asyn
       session_id: "session_id",
       cwd: "cwd",
       tool_name: "tool_name",
+      // The learner's answer to a parked retro question arrives here, so an
+      // unmapped `prompt` leaves every Codex question parked until its marker
+      // expires — the gate asks and nothing can ever answer.
+      prompt: "prompt",
       last_assistant_message: "last_assistant_message",
     },
   });
@@ -121,9 +125,36 @@ test("wires lifecycle and PreToolUse gates through frozen cross-platform shim co
           hooks: [hook("stop", "Checking the Altitude retro gate")],
         },
       ],
+      // Stop is END OF TURN, not end of session: workshop-core removes the
+      // session marker and emits `session_ended` only on this lifecycle.
+      SessionEnd: [
+        {
+          hooks: [hook("session-end", "Closing the Altitude workshop session")],
+        },
+      ],
+      // The other half of the retro gate — the turn where the learner answers
+      // the parked question — plus the turn-start credit stamp.
+      UserPromptSubmit: [
+        {
+          hooks: [hook("user-prompt-submit", "Recording your Altitude turn")],
+        },
+      ],
     },
   });
   assert.equal(Object.hasOwn(config.hooks, "PostToolUse"), false);
+});
+
+test("covers the same lifecycle surface as the Claude plugin", async () => {
+  const codex = await readJson("hooks/codex.json");
+  const claude = await readJson("hooks/hooks.json");
+
+  // Agent neutrality: a lifecycle wired for one agent and not the other is an
+  // adapter bug, and it is invisible until a bound session runs live. Codex
+  // 0.145.0 supports every event Claude Code does that we use.
+  assert.deepEqual(
+    Object.keys(codex.hooks).sort(),
+    Object.keys(claude.hooks).sort(),
+  );
 });
 
 test("the shim forwards exact lifecycle arguments and stdin to workshop-core", async (t) => {
@@ -162,6 +193,32 @@ test("the shim forwards exact lifecycle arguments and stdin to workshop-core", a
     "diff",
   ]);
   assert.equal(await readFile(stdinPath, "utf8"), payload);
+});
+
+test("the shim forwards the session-end and user-prompt-submit lifecycles", async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), "altitude-codex-lifecycle-"));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  const argvPath = join(temp, "argv");
+  await fakeExecutable(temp, "altitude", `printf '%s\\n' "$@" > "${argvPath}"`);
+  const base = ["--agent", "codex", "--mapping", join(repoRoot, "hooks/codex-field-mapping.json")];
+
+  for (const [action, lifecycle] of [
+    ["session-end", "session-end"],
+    ["user-prompt-submit", "user-prompt-submit"],
+  ]) {
+    const result = runShim([action], {
+      input: JSON.stringify({ session_id: `codex-${action}`, cwd: "/tmp/project" }),
+      env: { PATH: `${temp}${delimiter}${process.env.PATH}` },
+    });
+
+    assert.equal(result.status, 0, action);
+    // No `--gate`: neither lifecycle runs a gate, so neither can ever block.
+    assert.deepEqual(
+      (await readFile(argvPath, "utf8")).trim().split("\n"),
+      ["hook", lifecycle, ...base],
+      action,
+    );
+  }
 });
 
 test("the shim preserves exit 2 and the gate reason", async (t) => {


### PR DESCRIPTION
The Codex plugin wired `SessionStart`, `PreToolUse` and `Stop` only. Two consequences, neither visible to Claude Code users:

**Sessions never ended.** `Stop` is end of *turn* — workshop-core retires the session marker and emits `session_ended` solely on the `session-end` lifecycle. Every Codex session leaked its marker and never reported an end. The server still closed it by derived inactivity, so nothing looked broken.

**Retro answers were never captured.** `captureParkedAnswer` reads the learner's answer from `payload.prompt` on `UserPromptSubmit`. The retro gate asked its question, parked it, and nothing could ever answer — no `quiz_moment` evidence for any Codex learner, ever. `UserPromptSubmit` also stamps the turn-start credit target, so gate credit fell back to live-cache attribution. Claude Code got the prompt mapping in bedc2f7; Codex was missed.

## Changes

- `hooks/codex.json` — append `SessionEnd` and `UserPromptSubmit`
- `hooks/codex-field-mapping.json` — map `prompt`, without which `UserPromptSubmit` is inert
- `bin/altitude-codex-hook.mjs` — two new shim actions
- both plugin manifests — 0.5.0 → 0.5.1

## Hook trust

The new entries are **appended**. The trust state key is positional *per event* (`<event>:<group_idx>:<handler_idx>`), so existing `SessionStart`/`PreToolUse`/`Stop` trust is preserved and no command string changed. Existing Codex users get a one-keystroke "Hooks need review → Trust all and continue" prompt covering only the two new hooks.

## Verification

Codex 0.145.0 supports both events — hook-event enum read from the shipped binary: `PreToolUse, PermissionRequest, PostToolUse, PreCompact, PostCompact, SessionStart, SessionEnd, UserPromptSubmit, SubagentStart, SubagentStop, Stop`.

Tests written failing-first (4 red → 23/23 green), including a new parity test asserting both plugins wire the same lifecycle set — this gap was invisible until a bound session ran live.

Found by the nightly real-agent E2E in the main repo, which bound a scratch repo to a live journey for the first time today. Earlier green runs were dormant and asserted nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)