### PR TITLE
Rebuild /start-project's interview as breadth, depth, then playback

### DIFF
--- a/skills/start-project/SKILL.md
+++ b/skills/start-project/SKILL.md
@@ -21,21 +21,63 @@ You are a patient senior engineer helping a complete beginner pick and scope the
 
 Open by sketching the road in two or three lines before the first question: I'll get to know you, we'll pick a project sized to your level, trim it to an MVP, and map the core components you'll learn end to end — and the reason we start with you, not with code, is that concepts stick when they attach to something you actually care about. Then ask the first question.
 
-Ask, one at a time (skip any they've already answered):
+**What you are actually doing here.** You are not asking the learner to think up a software project. That is your job, in Phase 2, built out of what they tell you now. Ask them to **describe, never to invent**. Everyone can describe their own Tuesday; almost nobody can name a good first project cold.
 
-1. Have you ever written any code before — even a spreadsheet formula, or copy-pasting something? What happened?
-2. Have you ever used a terminal / command line?
-3. What do you do for work (or study), and what made you want to learn to code now?
-4. What's something you do repeatedly — daily or weekly — that feels tedious? Any app or tool you've wished existed?
-5. What are you into outside work? (Hobbies, communities, collections, sports, games — projects anchored to genuine interests get finished.)
+**What "covered" means.** A beat is covered when you have a **usable specific** — a thing, a name, a number, a routine you could describe back to them. "Work is busy", "the usual", and "idk, laundry?" are not answers; they are the start of one. When an answer is thin, vague, or a single word, follow up on it instead of moving on. Follow-ups *are* the interview, not a detour from it.
 
-If they arrive with a project idea already, skip to Phase 2 and evaluate *their* idea for size instead of proposing new ones.
+You may name two or three concrete examples inside a question so the learner can see the shape of a useful answer — beats 3 and 4 do exactly that. That is not the same as handing them a menu, which the hard rules forbid.
+
+Skip any beat they have already answered. Never re-ask something you already know.
+
+### Breadth — four beats, in this order
+
+1. "Before anything else — what do you actually do all day? Job titles never say much."
+2. "Walk me through your last working day, start to finish. What did you touch, who did you deal with, what took longer than it should have?"
+3. "Anything in there you do the same way every single time? People usually name things like the numbers they rebuild every Monday, the same reply typed for the tenth time, or a handover note nobody reads."
+4. "Now off the clock — what do you spend a Saturday or your own money on? Climbing, a fantasy league, houseplants, a band, a game." Then, once they have answered that: "and does anyone else need to see any of that — a partner, a group, a team?"
+
+The second half of beat 4 is deliberate. A project with a real second person in it is the difference between a toy and something the learner finishes and shows someone.
+
+You may tune the voice of these beats. Do not change what they ask for, and never merge two of them into one turn.
+
+### Where they're starting from — three beats
+
+Only after the breadth beats. Opening on somebody's credentials sets exactly the wrong tone, and none of the beats above need jargon.
+
+5. "Have you ever written any code before — even a spreadsheet formula, or copy-pasting something? What happened?"
+6. "Have you ever used a terminal, or a command line?"
+7. "What made you want to learn this now?"
+
+Use 5 and 6 to set your own vocabulary for the rest of the session — at the beginner end, no jargon at all — never to grade them. A naive, uncertain, or wrong answer is useful calibration, never failure.
+
+### Depth — two to four turns on one thread
+
+Now pick the **single richest thread** — the one with the most specific detail, a real person on the other end of it, or visible friction — and go deeper on it. Dig for:
+
+- what actually breaks, and what happens when it does;
+- what they track, and where it lives right now (a notebook, a spreadsheet, their own head);
+- who else touches it;
+- what they would do with the time if it stopped costing them anything.
+
+**Stay on one thread.** Do not tour all four breadth beats again. This is where the conversation stops feeling like a form, and it is where the project actually comes from.
+
+### Practical reality — one beat
+
+Then one short beat before you close: how many hours a week they can realistically give this. Ask it once, near the end — never open on logistics. Phase 2 sizes the project against that number.
+
+### Play it back
+
+Before you propose anything, play the conversation back in the learner's own nouns — "so: restaurant shifts, the Tuesday inventory count you do from memory, and the fantasy league you run for eleven people" — then move to Phase 2. That message carries no new question.
+
+If they arrive with a project idea already, still gather their days, their interests, and their hours — an idea can only be sized against a real life — but move faster, skip whatever their idea already answers, and in Phase 2 evaluate *their* idea for size instead of proposing new ones.
 
 ## Phase 2 — Propose and size the project
 
 Offer **2–3 project ideas** drawn from their answers. For each: one sentence on what it is, one sentence on why it fits their life, one sentence on why it's the right size.
 
-Sizing target: **challenging but not overwhelming.** A good first project has a visible result early, touches a real end-to-end stack, and can reach "usable" in weeks, not months.
+Ground at least two of the ideas in *different* things they actually told you — one in the repeated thing from beat 3, another in what they do off the clock. Three ideas drawn from the same thread is one idea wearing three hats.
+
+Sizing target: **challenging but not overwhelming.** A good first project has a visible result early, touches a real end-to-end stack, and can reach "usable" in weeks, not months. Size it against the hours a week they gave you, not against an imaginary full-time learner.
 
 Scope traps to steer away from (explain why if they ask for one):
 - Two-sided marketplaces, anything with payments, e-commerce builders
@@ -74,7 +116,10 @@ Create `learning/project.md`:
 # Project: <name>
 
 ## About me
-<experience profile from Phase 1 — 3-5 bullets, plain facts>
+<from Phase 1 — 3-6 bullets, plain facts in their own nouns: what their days
+contain, the repeated thing and where its data lives today, who else is
+involved, what they do off the clock, where they're starting from with code and
+the terminal, and the hours a week they said they have>
 
 ## The idea
 <2-3 sentences>

--- a/test/start-project.test.mjs
+++ b/test/start-project.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function readSkill() {
+  return readFile(join(repoRoot, "skills/start-project/SKILL.md"), "utf8");
+}
+
+/**
+ * The paid web onboarding interview was redesigned to `int-v4` (see
+ * `docs/interview-redesign.md` in the altitude repo). Its diagnosis applies here
+ * verbatim, because this skill carried the same script: asking a total beginner
+ * to invent a software project is the hardest creative act in the product, and
+ * it is the machine's job, not theirs. These tests pin the structural fixes so
+ * the free path cannot silently drift back to the old form.
+ */
+test("never asks the beginner to invent the project", async () => {
+  const skill = await readSkill();
+
+  // The exact question that started the redesign. It asks for a solution when
+  // the learner has no way to produce one, and the proposing step already does
+  // this work from their raw life detail.
+  assert.doesNotMatch(skill, /tool you wish(ed)? existed/i);
+  assert.doesNotMatch(skill, /app or tool you'?ve wished existed/i);
+  assert.match(
+    skill,
+    /describe, never to invent|never asking them to invent/i,
+    "the skill must state its own stance: the learner describes, the skill ideates",
+  );
+});
+
+test("gathers raw life detail through concrete breadth beats", async () => {
+  const skill = await readSkill();
+
+  assert.match(skill, /what do you actually do all day/i);
+  assert.match(skill, /last working day/i);
+  // The repeated-thing beat replaces "what feels tedious" — same target, but
+  // answerable from memory instead of requiring self-diagnosis.
+  assert.match(skill, /the same way every single time/i);
+  // A real second person is the difference between a toy and something the
+  // learner finishes and shows someone.
+  assert.match(skill, /anyone else need to see/i);
+});
+
+test("treats a thin answer as the start of one, not a covered topic", async () => {
+  const skill = await readSkill();
+
+  assert.match(skill, /usable specific/i);
+  assert.match(
+    skill,
+    /follow[- ]up/i,
+    "thin answers must earn a follow-up rather than a checkmark",
+  );
+});
+
+test("goes deep on one thread before proposing anything", async () => {
+  const skill = await readSkill();
+
+  assert.match(skill, /richest thread/i);
+  assert.match(skill, /stay on one thread/i);
+});
+
+test("keeps the experience questions this surface has no assessment for", async () => {
+  const skill = await readSkill();
+
+  // int-v4 dropped these on the web because the assessment already measured
+  // coding and AI depth and feeds them to the interviewer. This skill runs with
+  // no assessment at all, so here they are the only source of that calibration
+  // — porting int-v4's deletion would be porting it out of context.
+  assert.match(skill, /written any code/i);
+  assert.match(skill, /terminal/i);
+});
+
+test("asks how much time the learner actually has, once, near the end", async () => {
+  const skill = await readSkill();
+
+  assert.match(skill, /hours a week/i);
+  assert.match(skill, /never open on logistics/i);
+});
+
+test("plays the conversation back before proposing ideas", async () => {
+  const skill = await readSkill();
+
+  assert.match(skill, /play(s|ing)? (it |that |the conversation )?back/i);
+  assert.match(skill, /own nouns/i);
+});
+
+test("still forbids putting words in the learner's mouth", async () => {
+  const skill = await readSkill();
+
+  // Priming examples in prose are allowed (int-v4 decision 2); multiple-choice
+  // panels are not, and that ban predates the redesign.
+  assert.match(skill, /AskUserQuestion/);
+  assert.match(skill, /own words/i);
+});


### PR DESCRIPTION
Ports the structure of Altitude's `int-v4` web interview redesign to the free `/start-project` skill, so the free path stops asking the question that redesign was built to delete.

## Why

Phase 1 asked five flat questions. The fourth was:

> "What's something you do repeatedly — daily or weekly — that feels tedious? Any app or tool you've wished existed?"

That asks a complete beginner to perform the hardest creative act in the product — invent a software project — in one line, with no examples and no follow-up. Nobody untrained can answer it. Everybody can describe their own Tuesday. And Phase 2 *already* invents the project from their raw life detail, so the question duplicated the skill's own job and did it worse.

Nothing rewarded digging either: a learner who answered "idk, laundry?" got a tick and the interview moved on.

## What changes

- **The skill states its stance:** the learner describes, the skill ideates.
- **Four concrete breadth beats** anyone can answer from memory — what they do all day, their last working day start to finish, the thing they do the same way every single time, and what they do off the clock *plus who else needs to see it*. That last half-beat is deliberate: a project with a real second person in it is the difference between a toy and something the learner finishes and shows someone.
- **Priming examples inside the questions**, so the shape of a useful answer is visible. The existing ban on multiple-choice panels is untouched — answers stay free text in the learner's own words.
- **"Covered" is redefined as a usable specific.** A thin answer earns a follow-up, not a checkmark. This is the load-bearing change; the beat list is worthless without it.
- **Two to four turns of depth on the single richest thread**, staying on that thread. This is where it stops feeling like a form, and where the project actually comes from.
- **One practical-reality beat** on realistic weekly hours, asked once near the end, never as an opener. Phase 2 now sizes against it.
- **A playback** of the conversation in the learner's own nouns before any idea is proposed.

Phase 2 also gains an explicit instruction to ground at least two ideas in *different* things the learner said — three ideas from one thread is one idea wearing three hats.

## What deliberately did NOT port

`int-v4` dropped the prior-code and terminal questions, and never asked why-now. Both deletions were correct **there** and wrong here:

- Altitude's assessment measures coding and AI depth and feeds them to the web interviewer. This skill has no assessment.
- The web learner has already picked a goal. This skill has no selected goal.

So those three questions are this surface's only calibration. They stay — moved *after* the breadth beats, because opening on somebody's credentials sets the wrong tone.

## Note on timing

Altitude's design record deferred this port until `int-v4` had beta evidence, so the free path would inherit a proven script. That deferral is reversed on the argument that the diagnosis being fixed is **structural**, not tuned: solution-space questions, thin answers waved through, and no depth phase are wrong for the same reasons on both surfaces. Beta evidence would refine *wording*. So the structure ported and nothing speculative did.

## Testing

New `test/start-project.test.mjs` pins the structural fixes so the free path can't silently drift back. Written failing first — 6 of 8 red, the 2 green being the deletions that were meant to stay green.

`npm test`: **31/31 passing.**

Not merging this myself — it publishes to the plugin marketplace, so the call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkGq36w2mE4euLBDQBy7MH