### PR TITLE
docs(readme): fix the install path that stranded the first beta tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,22 @@ The free method is complete and works standalone: `/start-project` + `/plan-jour
 
 ## Install
 
-**As a plugin** (recommended — it updates with the repo). In Claude Code, type both lines inside the agent:
+**As a plugin** (recommended — it updates with the repo). Open a terminal and run `claude` to start Claude Code:
+
+```bash
+claude
+```
+
+Then type these two lines inside that session:
 
 ```
 /plugin marketplace add jasonku09/altitude-skills
 /plugin install altitude@altitude
 ```
+
+`/plugin` exists only in the terminal app. Pasted into an IDE extension's chat panel it answers "plugin isn't available in this environment" — that's the wrong window, not a broken install. (The VS Code and JetBrains extensions are documented to have their own graphical `/plugins` manager — note the plural — which should also get you there; the terminal route above is the one we test.)
+
+**When the install asks where to put the plugin, choose the user scope** — the "for yourself, across all projects" option. Your first lesson makes a brand-new project folder, and a project- or local-scoped install writes into the folder you're standing in right now, so it would stay behind exactly when the skills are needed. If the install summary asks you to run `/reload-plugins`, run it; newer versions activate the plugin in place and tell you "Plugin is now active" instead.
 
 In Codex, run both lines in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -65,25 +65,27 @@ codex plugin add altitude@altitude
 
 The first `codex` launch after installing shows a one-time "Hooks need review" prompt — choose **Trust all and continue** to enable Altitude's session hooks. (They stay dormant outside bound journey projects; see below.)
 
-**Or copy the skills directly** (Claude Code):
+The plugin also bundles Altitude's session hooks (`hooks/`). They stay fully dormant unless you're working inside a project bound to a subscribed journey (`altitude bind` / `/altitude:begin`) — no events, gates, or context injection anywhere else. With a bound project, they capture session evidence for your journey and run the plan/diff/retro gates. Gates fail open: a crashed hook never blocks your work. The `/altitude:connect` and `/altitude:status` skills manage the link.
+
+Once it's installed: for the free standalone method, open a new Claude Code session in an empty folder and run `/start-project`. If you planned a subscribed journey on Altitude, install its CLI, connect with `/altitude:connect`, and run `/altitude:begin` instead.
+
+**Or copy the skills directly** — for the free standalone method only (Claude Code):
 
 ```bash
 git clone https://github.com/jasonku09/altitude-skills.git
 cp -r altitude-skills/skills/* ~/.claude/skills/
 ```
 
-For the standalone method, open a new Claude Code session in an empty folder and run `/start-project`. If you planned a subscribed journey on Altitude, install its CLI, connect with `/altitude:connect`, and run `/altitude:begin` instead.
+That copies the skills and nothing else: **no session hooks**, and no auto-update (re-run the clone + copy for new versions). The free method needs neither, so this route is complete for `/start-project` → `/plan-journey` → `/next-lesson`. **With an Altitude subscription, install the plugin instead.** The hooks are what capture session evidence and run the gates, they live outside `skills/`, and a copied install has no `/altitude:` commands to connect or begin with — and nothing would tell you: gates fail open, so the only symptom is a learning map that never fills.
 
-The plugin also bundles Altitude's session hooks (`hooks/`). They stay fully dormant unless you're working inside a project bound to a subscribed journey (`altitude bind` / `/altitude:begin`) — no events, gates, or context injection anywhere else. With a bound project, they capture session evidence for your journey and run the plan/diff/retro gates. Gates fail open: a crashed hook never blocks your work. The `/altitude:connect` and `/altitude:status` skills manage the link.
-
-**Using Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which Cursor supports — copy them in:
+**Using Cursor instead?** These skills use the open [Agent Skills](https://agentskills.io) format, which Cursor supports — copy them in for the free standalone method:
 
 ```bash
 git clone https://github.com/jasonku09/altitude-skills.git
 cp -r altitude-skills/skills/* ~/.cursor/skills/   # pick via / in Agent chat, or automatic
 ```
 
-Copied skills don't auto-update — re-run the clone + copy to pick up new versions. And [PROMPTS.md](PROMPTS.md) works with any agent at all, no install needed.
+Same caveats as the copy above, plus one more: Cursor has no Altitude hooks at all, so a subscribed journey needs Claude Code or Codex. And [PROMPTS.md](PROMPTS.md) works with any agent at all, no install needed.
 
 ## How to use it
 

--- a/test/claude-plugin.test.mjs
+++ b/test/claude-plugin.test.mjs
@@ -213,6 +213,48 @@ test("README installs the plugin from a terminal, with scope and reload guidance
   assert.match(readme, /\/reload-plugins/);
 });
 
+test("README fences the direct-copy install off from hooks and subscribers", async () => {
+  const readme = await readFile(join(repoRoot, "README.md"), "utf8");
+
+  const start = readme.indexOf("**Or copy the skills directly**");
+  const end = readme.indexOf("**Using Cursor instead?**");
+  assert.ok(start !== -1 && end > start, "the direct-copy install block moved or vanished");
+  const copyBlock = readme.slice(start, end);
+
+  // `hooks/` sits outside `skills/`, and every hook command resolves
+  // `${CLAUDE_PLUGIN_ROOT}` — a variable only a plugin install defines. So
+  // `cp -r skills/*` yields working slash commands and no session hooks: no
+  // evidence capture, no gates. Gates fail open by design, so nothing errors;
+  // a subscriber's only symptom is a learning map that never fills. The
+  // warning has to sit with the commands, not three paragraphs below them.
+  assert.match(copyBlock, /no session hooks/i, "must say the copy carries no hooks");
+  assert.match(copyBlock, /free standalone method/i, "must scope the copy to the free method");
+  assert.match(copyBlock, /subscription/i, "must send subscribers back to the plugin");
+
+  // A copied skill is invoked by its own `name` — `/connect`, not
+  // `/altitude:connect`, which exists only under the plugin's namespace. The
+  // paid route must not be described as reachable from a copied install.
+  assert.doesNotMatch(
+    copyBlock,
+    /\/altitude:connect/,
+    "a copied install has no /altitude: namespace to connect with",
+  );
+});
+
+test("README scopes the Cursor copy to the free method too", async () => {
+  const readme = await readFile(join(repoRoot, "README.md"), "utf8");
+
+  const cursorBlock = readme.slice(readme.indexOf("**Using Cursor instead?**"));
+  assert.match(cursorBlock, /~\/\.cursor\/skills/, "the Cursor copy block moved or vanished");
+  // Same mechanism, same silent loss: skills copy over, hooks do not exist to
+  // copy, and Cursor has no Altitude hook adapter at all.
+  assert.match(
+    cursorBlock.slice(0, cursorBlock.indexOf("## How to use it")),
+    /free standalone method/i,
+    "must scope the Cursor copy to the free method",
+  );
+});
+
 test("keeps the Claude adapter surface free of server-owned teaching content", async () => {
   const distributable = [
     ".claude-plugin/plugin.json",

--- a/test/claude-plugin.test.mjs
+++ b/test/claude-plugin.test.mjs
@@ -193,6 +193,26 @@ test("ships one status skill that serves both agents", async () => {
   assert.match(status, /\$connect/);
 });
 
+test("README installs the plugin from a terminal, with scope and reload guidance", async () => {
+  const readme = await readFile(join(repoRoot, "README.md"), "utf8");
+
+  // `/plugin` is a terminal-only command. Telling a learner to type it "inside
+  // the agent" sends IDE-extension users to a chat panel that answers "plugin
+  // isn't available in this environment", and they cannot find Claude Code at
+  // all from there — this is where the first beta tester stranded (2026-08-08).
+  // The install has to start by opening a terminal and running `claude`.
+  assert.doesNotMatch(readme, /type both lines inside the agent/i);
+  assert.match(readme, /Open a terminal and run `claude`/);
+
+  // `/plugin install` prompts for an install scope. Project scope writes
+  // `.claude/settings.json` and local scope `.claude/settings.local.json` into
+  // whatever folder the learner is standing in — both left behind the moment
+  // their first lesson creates its own project folder, which is precisely when
+  // the skills are needed. Name the user scope, and the reload follow-up.
+  assert.match(readme, /user scope/);
+  assert.match(readme, /\/reload-plugins/);
+});
+
 test("keeps the Claude adapter surface free of server-owned teaching content", async () => {
   const distributable = [
     ".claude-plugin/plugin.json",


### PR DESCRIPTION
Two install defects found in the 2026-08-08 live user-testing session and the follow-up audit. Docs + tests only — no skill or hook behavior changes.

## 1. `/plugin` is terminal-only (fec18f2 → 4350e93)

The README said to type both `/plugin` lines "inside the agent". The tester pasted them into the VS Code extension's chat panel and got *"plugin isn't available in this environment"* — he could not find Claude Code at all from there. The install now opens with a terminal and `claude`, and names the extension's own graphical `/plugins` manager only as an aside.

`/plugin install` also prompts for a scope, and the README said nothing. Project or local scope writes into whatever folder you're standing in — left behind the moment the first lesson creates its own project folder, which is exactly when the skills are needed. The README now names the **user** scope and why, plus the `/reload-plugins` follow-up.

## 2. A copied install silently carries no hooks (076eca3)

`cp -r altitude-skills/skills/* ~/.claude/skills/` was documented as a plain alternative to the plugin. It isn't one:

- `hooks/` sits **outside** `skills/`, so the copy brings zero hook files.
- Every hook command resolves `${CLAUDE_PLUGIN_ROOT}` (Codex: `$PLUGIN_ROOT`) — undefined outside a plugin install, so hand-copying them wouldn't work either.
- Copied skills are invoked by their frontmatter `name` (`/connect`), so there is no `/altitude:` namespace — while the next paragraph told those users to run `/altitude:connect`.
- **Gates fail open by design**, so nothing errors. A subscriber gets working slash commands, no evidence capture, no gates, and the only symptom is a learning map that never fills.

Both copy routes (Claude Code and Cursor) are now scoped to the free standalone method, state what they leave out, and send subscribers to the plugin. The hooks paragraph and the post-install orientation moved above the copy block so the paid route is described where it actually works.

## Verification

`npm test` — **34/34 green**. Three README assertions added across the two commits; the two new ones were watched fail first (`must say the copy carries no hooks`, `must scope the Cursor copy to the free method`).

Note for the record: an earlier reading of this defect blamed the Altitude web app's connect page. That was wrong — `apps/web/src/agents/registry.ts` already installs both agents through the marketplace and needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHmuZGGvddH53eypKu7Re7